### PR TITLE
fix: solved issue with optimisation not showing in dash

### DIFF
--- a/inc/rest.php
+++ b/inc/rest.php
@@ -429,6 +429,15 @@ class Optml_Rest {
 
 		$final_images = array_splice( $images['list'], 0, 10 );
 
+		$final_images = array_map(
+			function ( $item ) {
+					$item['ex_size_raw'] = intval( $item['ex_size'] );
+					$item['new_size_raw'] = intval( $item['new_size'] );
+					return $item;
+			},
+			$final_images
+		);
+
 		return $this->response( $final_images );
 	}
 


### PR DESCRIPTION
The stats from the dashboard had perviously 2 extra keys just holding `intval()` of existing keys.
I've added a map to just add those keys only for this last 10 images before display.

The rest is handled by VUE
