### PR TITLE
fix: small parse fix for lazyload

### DIFF
--- a/inc/manager.php
+++ b/inc/manager.php
@@ -443,8 +443,9 @@ final class Optml_Manager {
 					unset( $images[ $key ] );
 					continue;
 				}
-				$is_no_script = false;
+
 				foreach ( $unused as $url_key => $url_value ) {
+					$is_no_script = false;
 					if ( $key === 'img_url' ) {
 						$images[ $key ][ $url_key ] = rtrim( $url_value[0], '\\' );
 						continue;

--- a/inc/manager.php
+++ b/inc/manager.php
@@ -435,7 +435,7 @@ final class Optml_Manager {
 			$header_end   = $header_start + strlen( $matches[0][0] );
 		}
 
-		if ( preg_match_all( '/(?:<a[^>]+?href=["|\'](?P<link_url>[^\s]+?)["|\'][^>]*?>\s*)?(?P<img_tag>(?:<noscript\s*>\s*)?<img[^>]*?\s+?(?:' . implode( '|', array_merge( [ 'src' ], Optml_Tag_Replacer::possible_src_attributes() ) ) . ')=\\\\?["|\'](?P<img_url>[^\s]+?)["|\'].*?>){1}(?:<\/noscript\s*>)?(?:\s*<\/a>)?/ism', $content, $images, PREG_OFFSET_CAPTURE ) ) {
+		if ( preg_match_all( '/(?:<a[^>]+?href=["|\'](?P<link_url>[^\s]+?)["|\'][^>]*?>\s*)?(?P<img_tag>(?:<noscript\s*>\s*)?<img[^>]*?\s+?(?:' . implode( '|', array_merge( [ 'src' ], Optml_Tag_Replacer::possible_src_attributes() ) ) . ')=\\\\?["|\'](?P<img_url>[^\s]+?)["|\'].*?>(?:<\/noscript\s*>)?){1}(?:\s*<\/a>)?/ism', $content, $images, PREG_OFFSET_CAPTURE ) ) {
 
 			foreach ( $images as $key => $unused ) {
 				// Simplify the output as much as possible, mostly for confirming test results.
@@ -444,8 +444,8 @@ final class Optml_Manager {
 					continue;
 				}
 
+				$is_no_script = false;
 				foreach ( $unused as $url_key => $url_value ) {
-					$is_no_script = false;
 					if ( $key === 'img_url' ) {
 						$images[ $key ][ $url_key ] = rtrim( $url_value[0], '\\' );
 						continue;

--- a/tests/test-lazyload.php
+++ b/tests/test-lazyload.php
@@ -244,6 +244,22 @@ class Test_Lazyload extends WP_UnitTestCase {
 		$this->assertEquals( 4, substr_count( $replaced_content, 'i.optimole.com' ) );
 	}
 
+	public function test_check_lazy_load_after_no_script() {
+		$content = '<noscript><img height="1" width="1" style="display:none" alt="fbpx" src="https://www.facebook.com/tr?id=dasda&ev=PageView&noscript=1" /></noscript>
+			<a href="/project/test-one"><span class="et_pb_image_wrap"><img src="http://example.org/wp-content/uploads/2018/11/gradient.png" alt="" /></span></a>
+			<a href="/project/test-two"><span class="et_pb_image_wrap"><img src="http://example.org/wp-content/uploads/2018/11/gradient.png" alt="" /></span></a>
+			<a href="/project/test-three"><span class="et_pb_image_wrap"><img src="http://example.org/wp-content/uploads/2018/11/gradient.png" alt="" /></span></a>
+		';
+
+		$replaced_content = Optml_Manager::instance()->replace_content( $content );
+
+		$this->assertContains( '<noscript>', $replaced_content );
+		$this->assertEquals( 4, substr_count( $replaced_content, '<noscript>' ) );
+		$this->assertEquals( 9, substr_count( $replaced_content, 'i.optimole.com' ) );
+		$this->assertEquals( 3, substr_count( $replaced_content, 'data-opt-src' ) );
+		$this->assertEquals( 3, substr_count( $replaced_content, '/q:eco/' ) );
+		$this->assertEquals( 6, substr_count( $replaced_content, '/q:auto/' ) );
+	}
 
 	public function test_replacement_with_data_attr() {
 		$content = '<div class="before-footer">


### PR DESCRIPTION
Should solve an edge case where if it encounters early a `<noscript>` tag it will mark all subsequent resources as `in_header` and exclude them from lazy-load 
 
