### PR TITLE
chore: fix losing filters settings after disconnecting the api key

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -402,9 +402,12 @@ class Optml_Settings {
 	 * @return bool Reset action status.
 	 */
 	public function reset() {
-		$update = update_option( $this->namespace, $this->default_schema );
+		$reset_schema = $this->default_schema;
+		$reset_schema['filters'] = $this->options['filters'];
+
+		$update = update_option( $this->namespace, $reset_schema );
 		if ( $update ) {
-			$this->options = $this->default_schema;
+			$this->options = $reset_schema;
 		}
 
 		return $update;


### PR DESCRIPTION
The filters are being reset once the API key is disconnected.
This should keep the filters after the API key is disconnected.

References #206 