### PR TITLE
chore: fix exclude iframes before adding to replace

### DIFF
--- a/inc/lazyload_replacer.php
+++ b/inc/lazyload_replacer.php
@@ -36,6 +36,12 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 	 */
 	private static $ignore_no_script_flags = null;
 	/**
+	 * Holds possible iframe lazyload flags where we should ignore our lazyload.
+	 *
+	 * @var array
+	 */
+	protected static $iframe_lazyload_flags = null;
+	/**
 	 * Holds classes responsabile for watching lazyload behaviour.
 	 *
 	 * @var array Lazyload classes.
@@ -258,7 +264,7 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 		$search = array();
 		$replace = array();
 		foreach ( $video_tags[0] as $video_tag ) {
-			if ( strpos( $video_tag, 'gform_ajax_frame' ) ) {
+			if ( ! $this->should_lazyload_iframe( $video_tag ) ) {
 				continue;
 			}
 			if ( preg_match( "/ data-opt-video-src=['\"]/is", $video_tag ) ) {
@@ -393,6 +399,22 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 
 		return true;
 	}
+	/**
+	 * Check if we should lazyload iframe.
+	 *
+	 * @param string $tag Html tag.
+	 *
+	 * @return bool Should add?
+	 */
+	public function should_lazyload_iframe( $tag ) {
+		foreach ( self::get_iframe_lazyload_flags() as $banned_string ) {
+			if ( strpos( $tag, $banned_string ) !== false ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
 
 	/**
 	 * Returns flags for ignoring noscript tag additional watch.
@@ -409,7 +431,21 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 
 		return self::$ignore_no_script_flags;
 	}
+	/**
+	 * Returns possible lazyload flags for iframes.
+	 *
+	 * @return array
+	 */
+	public static function get_iframe_lazyload_flags() {
 
+		if ( null != self::$iframe_lazyload_flags && is_array( self::$iframe_lazyload_flags ) ) {
+			return self::$iframe_lazyload_flags;
+		}
+
+		self::$iframe_lazyload_flags = apply_filters( 'optml_iframe_lazyload_flags', [ 'gform_ajax_frame' ] );
+
+		return self::$iframe_lazyload_flags;
+	}
 	/**
 	 * Throw error on object clone
 	 *

--- a/inc/lazyload_replacer.php
+++ b/inc/lazyload_replacer.php
@@ -258,13 +258,13 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 		$search = array();
 		$replace = array();
 		foreach ( $video_tags[0] as $video_tag ) {
-			array_push( $search, $video_tag );
 			if ( strpos( $video_tag, 'gform_ajax_frame' ) ) {
 				continue;
 			}
 			if ( preg_match( "/ data-opt-video-src=['\"]/is", $video_tag ) ) {
 				continue;
 			}
+			array_push( $search, $video_tag );
 			$no_script = $video_tag;
 			// replace the src and add the data-opt-src attribute
 			$video_tag = preg_replace( '/iframe(.*?)src=/is', 'iframe$1 src="about:blank" data-opt-src=', $video_tag );

--- a/tests/test-lazyload.php
+++ b/tests/test-lazyload.php
@@ -435,4 +435,18 @@ src="https://www.facebook.com/tr?id=472300923567306&ev=PageView&noscript=1" />
 		$this->assertEquals( 2, substr_count( $replaced_content, '<noscript>' ) );
 
 	}
+	public function test_lazyload_iframe_exclusion() {
+
+		$content = '<figure class="wp-block-embed-youtube wp-block-embed is-type-video is-provider-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio">
+					<div class="wp-block-embed__wrapper">
+					<iframe id="gform_ajax_frame" title="test" width="640" height="360" src="https://www.youtube.com/embed/-HwJNxE7hd8?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+					</div></figure>
+					<iframe id="gform_ajax_frame_7" width="930" height="523" src="http://5c128bbdd3b4.ngrok.io/" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>';
+		
+		$replaced_content = Optml_Manager::instance()->replace_content( $content );
+		$this->assertNotContains( 'src="about:blank"', $replaced_content );
+		$this->assertNotContains( 'data-opt-src', $replaced_content );
+		$this->assertNotContains( '<noscript>', $replaced_content );
+		
+	}
 }


### PR DESCRIPTION
One user reported that iframe lazyload breaks gravity forms https://secure.helpscout.net/conversation/1264680679/242528?folderId=2353196. I tested and he is right, gravity forms where excluded after being adding to the search array and where replaced with empty strings. I fixed it by excluding early.