### PR TITLE
Fix/url regex partial match

### DIFF
--- a/inc/manager.php
+++ b/inc/manager.php
@@ -456,7 +456,7 @@ final class Optml_Manager {
 		if ( $this->settings->use_cdn() && ! self::should_ignore_image_tags() ) {
 			$extensions = array_merge( $extensions, array_keys( Optml_Config::$assets_extensions ) );
 		}
-		$regex = '/(?:[(|\s\';",=])((?:http|\/|\\\\){1}(?:[' . Optml_Config::$chars . ']{10,}\.(?:' . implode( '|', $extensions ) . ')))(?=(?:|\?|"|&|,|\s|\'|\)|\||\\\\|}))/Uu';
+		$regex = '/(?:[(|\s\';",=])((?:http|\/|\\\\){1}(?:[' . Optml_Config::$chars . ']{10,}\.(?:' . implode( '|', $extensions ) . ')))(?=(?:http|>|%3F|\?|"|&|,|\s|\'|\)|\||\\\\|}))/Uu';
 		preg_match_all(
 			$regex,
 			$content,

--- a/tests/test-replacer.php
+++ b/tests/test-replacer.php
@@ -205,6 +205,18 @@ class Test_Replacer extends WP_UnitTestCase {
 		$this->assertEquals( 3, substr_count( $replaced_content, '/f:js/' ) );
 		$this->assertEquals( 3, substr_count( $replaced_content, '/m:0/' ) );
 		$this->assertEquals( 3, substr_count( $replaced_content, '/m:1/' ) );
+		$edge_case_urls = '
+						https://example.org/wp-content/plugins/divi-bars/assets/js/snap.svg-min.js
+						http://example.org/wp-content/plugins/divi-bars/assets/js/snap.svg-min.js
+						http://example.org/wp-includes/js/hoverintent-js.min.png-random.css
+						http://example.org/wp-includes/js/assets/whatever.jpg.png.css.js
+						';
+		$replaced_content = Optml_Manager::instance()->replace_content( $edge_case_urls );
+
+		$this->assertContains( 'https://test123.i.optimole.com/F7bDy7k-qJfPUR5J/f:js/q:auto/m:0/https://example.org/wp-content/plugins/divi-bars/assets/js/snap.svg-min.js', $replaced_content );
+		$this->assertContains( 'https://test123.i.optimole.com/F7bDy7k-fXTTyV95/f:js/q:auto/m:0/http://example.org/wp-content/plugins/divi-bars/assets/js/snap.svg-min.js', $replaced_content );
+		$this->assertContains( 'https://test123.i.optimole.com/F7bDy7k-DQ9xsda6/f:css/q:auto/m:1/http://example.org/wp-includes/js/hoverintent-js.min.png-random.css', $replaced_content );
+		$this->assertContains( 'https://test123.i.optimole.com/F7bDy7k-gtTzWlC5/f:js/q:auto/m:0/http://example.org/wp-includes/js/assets/whatever.jpg.png.css.js', $replaced_content );
 
 		$settings = new Optml_Settings();
 		$settings->update( 'css_minify', 'disabled' );


### PR DESCRIPTION
Right now the url regex fails for urls that contain more than one extension name,stopping at first extension found. eg:

http://example.org/wp-includes/js/snap.svg-min.js

I have added the modified regex here: 

https://regex101.com/r/XM42sO/12/

And the original regex here: 

https://regex101.com/r/XM42sO/11/