### PR TITLE
style: adds Prettier to run with ESLint

### DIFF
--- a/cypress/.eslintrc.json
+++ b/cypress/.eslintrc.json
@@ -22,6 +22,13 @@
     "space-in-parens": "off",
     "no-unused-vars": "error",
     "no-unused-expressions": "error",
-    "prefer-const": "error"
+    "prefer-const": "error",
+    "prettier/prettier": [
+      "error",
+      {},
+      {
+        "usePrettierrc": false
+      }
+    ]
   }
 }

--- a/cypress/.prettierrc.json
+++ b/cypress/.prettierrc.json
@@ -3,5 +3,7 @@
 	"tabWidth": 2,
 	"semi": true,
 	"singleQuote": true,
-	"printWidth": 100
+	"printWidth": 100,
+	"bracketSpacing": true,
+	"arrowParens": "always"
 }

--- a/cypress/integration/test_amp.js
+++ b/cypress/integration/test_amp.js
@@ -1,17 +1,21 @@
-describe('Check amp page', function () {
-  it('successfully loads', function () {
-    cy.visit('/amp-mode/?amp');
+describe("Check amp page", function () {
+  it("successfully loads", function () {
+    cy.visit("/amp-mode/?amp");
   });
 
-  it('AMP body has Optimole no script class', function () {
-    cy.get('html').not('.optml_no_js');
+  it("AMP body has Optimole no script class", function () {
+    cy.get("html").not(".optml_no_js");
   });
 
-  it('AMP images should have replaced srcs', function () {
-    cy.get('amp-img').should('have.attr', 'src').and('include', 'i.optimole.com');
+  it("AMP images should have replaced srcs", function () {
+    cy.get("amp-img")
+      .should("have.attr", "src")
+      .and("include", "i.optimole.com");
   });
 
-  it('AMP no script lazyload', function () {
-    cy.get('script').contains('d5jmkjjpb7yfg.cloudfront.net').should('not.exist');
+  it("AMP no script lazyload", function () {
+    cy.get("script")
+      .contains("d5jmkjjpb7yfg.cloudfront.net")
+      .should("not.exist");
   });
 });

--- a/cypress/integration/test_beaver_builder_background_lazyload.js
+++ b/cypress/integration/test_beaver_builder_background_lazyload.js
@@ -1,61 +1,61 @@
-describe('Check Homepage', function () {
-  it('successfully loads', function () {
-    cy.visit('/beaver/');
+describe("Check Homepage", function () {
+  it("successfully loads", function () {
+    cy.visit("/beaver/");
   });
-  it('Beaver column should have background lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.fl-col-content')
+  it("Beaver column should have background lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".fl-col-content")
       .eq(0)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
-  it('Beaver column should have background lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.fl-col-content')
+  it("Beaver column should have background lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".fl-col-content")
       .eq(1)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
-  it('Beaver column should have background lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.fl-col-content')
+  it("Beaver column should have background lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".fl-col-content")
       .eq(2)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
-  it('Beaver row content should have background lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.fl-row-bg-photo > .fl-row-content-wrap')
+  it("Beaver row content should have background lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".fl-row-bg-photo > .fl-row-content-wrap")
       .eq(0)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
-  it('Beaver row content not in view should  have no background', function () {
-    cy.get('.entry-content')
-      .find('.fl-row-bg-photo > .fl-row-content-wrap')
+  it("Beaver row content not in view should  have no background", function () {
+    cy.get(".entry-content")
+      .find(".fl-row-bg-photo > .fl-row-content-wrap")
       .eq(1)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('Beaver background image not in view should have no background', function () {
-    cy.get('.entry-content')
-      .find('.fl-col-content')
+  it("Beaver background image not in view should have no background", function () {
+    cy.get(".entry-content")
+      .find(".fl-col-content")
       .eq(4)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('After scroll the background images that come in view should be loaded', function () {
+  it("After scroll the background images that come in view should be loaded", function () {
     cy.scrollTo(0, 2500);
 
-    cy.get('.entry-content')
-      .find('.fl-col-content')
+    cy.get(".entry-content")
+      .find(".fl-col-content")
       .eq(4)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
-    cy.get('.entry-content')
-      .find('.fl-row-bg-photo > .fl-row-content-wrap')
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
+    cy.get(".entry-content")
+      .find(".fl-row-bg-photo > .fl-row-content-wrap")
       .eq(1)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
 });

--- a/cypress/integration/test_divi_background_lazyload.js
+++ b/cypress/integration/test_divi_background_lazyload.js
@@ -1,106 +1,106 @@
-describe('Check Divi Background Page', function () {
-  it('successfully loads', function () {
-    cy.visit('/divi/');
+describe("Check Divi Background Page", function () {
+  it("successfully loads", function () {
+    cy.visit("/divi/");
   });
   //from here
-  it('Divi slide that is in view should have optml-bg-lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.et_pb_slides > .et_pb_slide_0')
+  it("Divi slide that is in view should have optml-bg-lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".et_pb_slides > .et_pb_slide_0")
       .eq(0)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
-  it('Divi slide that is not in view should have background none', function () {
-    cy.get('.entry-content')
-      .find('.et_pb_slides > .et_pb_slide_1')
+  it("Divi slide that is not in view should have background none", function () {
+    cy.get(".entry-content")
+      .find(".et_pb_slides > .et_pb_slide_1")
       .eq(0)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('Divi slide that is not in view should have background none', function () {
-    cy.get('.entry-content')
-      .find('.et_pb_slides > .et_pb_slide_2')
+  it("Divi slide that is not in view should have background none", function () {
+    cy.get(".entry-content")
+      .find(".et_pb_slides > .et_pb_slide_2")
       .eq(0)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
   //to here we test the slider
   //from here we test the standard divi module where you can have background images
   //and the row background, section background
-  it('Divi row that is in view should have optml-bg-lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.et_pb_row_0')
+  it("Divi row that is in view should have optml-bg-lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".et_pb_row_0")
       .eq(0)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
-  it('Divi module that is in view should have optml-bg-lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.et_pb_module')
+  it("Divi module that is in view should have optml-bg-lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".et_pb_module")
       .eq(1)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
-  it('Divi slide that is not in view should have optml-bg-lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.et_pb_slides > .et_pb_slide_3')
+  it("Divi slide that is not in view should have optml-bg-lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".et_pb_slides > .et_pb_slide_3")
       .eq(0)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('Divi slide that is not in view should have optml-bg-lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.et_pb_slides > .et_pb_slide_4')
+  it("Divi slide that is not in view should have optml-bg-lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".et_pb_slides > .et_pb_slide_4")
       .eq(0)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('Divi row that is not in view should have background', function () {
-    cy.get('.entry-content')
-      .find('.et_pb_module')
+  it("Divi row that is not in view should have background", function () {
+    cy.get(".entry-content")
+      .find(".et_pb_module")
       .eq(4)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('Divi module that is not in view should have background', function () {
-    cy.get('.entry-content')
-      .find('.et_pb_row_3')
+  it("Divi module that is not in view should have background", function () {
+    cy.get(".entry-content")
+      .find(".et_pb_row_3")
       .eq(0)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('Divi module that is not in view should have background', function () {
-    cy.get('.entry-content')
-      .find('.et_pb_with_background')
+  it("Divi module that is not in view should have background", function () {
+    cy.get(".entry-content")
+      .find(".et_pb_with_background")
       .eq(1)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('After scroll the background images that come in view should be loaded', function () {
+  it("After scroll the background images that come in view should be loaded", function () {
     cy.scrollTo(0, 4250);
 
-    cy.get('.entry-content')
-      .find('.et_pb_slides > .et_pb_slide_3')
+    cy.get(".entry-content")
+      .find(".et_pb_slides > .et_pb_slide_3")
       .eq(0)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
 
-    cy.get('.entry-content')
-      .find('.et_pb_module')
+    cy.get(".entry-content")
+      .find(".et_pb_module")
       .eq(4)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
 
-    cy.get('.entry-content')
-      .find('.et_pb_row_3')
+    cy.get(".entry-content")
+      .find(".et_pb_row_3")
       .eq(0)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
 
-    cy.get('.entry-content')
-      .find('.et_pb_with_background')
+    cy.get(".entry-content")
+      .find(".et_pb_with_background")
       .eq(1)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
 });

--- a/cypress/integration/test_elementor.js
+++ b/cypress/integration/test_elementor.js
@@ -1,52 +1,54 @@
-describe('Check Homepage', function () {
-  it('successfully loads', function () {
-    cy.visit('/');
+describe("Check Homepage", function () {
+  it("successfully loads", function () {
+    cy.visit("/");
   });
-  const nativeLazy = 'loading' in HTMLImageElement.prototype;
-  it('Header should not have lazyload applied', function () {
-    cy.get('header img').should('not.have.attr', 'data-opt-src');
+  const nativeLazy = "loading" in HTMLImageElement.prototype;
+  it("Header should not have lazyload applied", function () {
+    cy.get("header img").should("not.have.attr", "data-opt-src");
   });
-  it('Elementor images should have replaced srcs', function () {
-    cy.get('.elementor-image > img').should('have.attr', 'src').and('include', 'i.optimole.com');
+  it("Elementor images should have replaced srcs", function () {
+    cy.get(".elementor-image > img")
+      .should("have.attr", "src")
+      .and("include", "i.optimole.com");
   });
 
-  it('Elementor images should data-opt-src attribute', function () {
+  it("Elementor images should data-opt-src attribute", function () {
     if (nativeLazy) {
       this.skip();
     }
-    cy.get('.elementor-image > img')
-      .should('have.attr', 'data-opt-src')
-      .and('include', 'i.optimole.com');
+    cy.get(".elementor-image > img")
+      .should("have.attr", "data-opt-src")
+      .and("include", "i.optimole.com");
   });
 
-  it('Elementor images should have no script tag', function () {
-    cy.get('.elementor-image > noscript').should('exist');
-    cy.get('.elementor-image > noscript')
-      .should('contain', 'img')
-      .should('contain', 'i.optimole.com');
+  it("Elementor images should have no script tag", function () {
+    cy.get(".elementor-image > noscript").should("exist");
+    cy.get(".elementor-image > noscript")
+      .should("contain", "img")
+      .should("contain", "i.optimole.com");
   });
 
-  it('Custom crop should have rt fill resize', function () {
+  it("Custom crop should have rt fill resize", function () {
     if (nativeLazy) {
       this.skip();
     }
-    cy.get('.custom-crop .elementor-image > img')
-      .should('have.attr', 'data-opt-src')
-      .and('include', 'i.optimole.com')
-      .and('include', 'rt:fill');
+    cy.get(".custom-crop .elementor-image > img")
+      .should("have.attr", "data-opt-src")
+      .and("include", "i.optimole.com")
+      .and("include", "rt:fill");
   });
 
-  it('Elementor gallery should be properly replaced', function () {
-    cy.get('.elementor-image-gallery  a ')
-      .should('have.attr', 'href')
-      .and('include', 'i.optimole.com');
-    cy.get('.elementor-image-gallery  a > img')
-      .should('have.attr', 'src')
-      .and('include', 'i.optimole.com');
+  it("Elementor gallery should be properly replaced", function () {
+    cy.get(".elementor-image-gallery  a ")
+      .should("have.attr", "href")
+      .and("include", "i.optimole.com");
+    cy.get(".elementor-image-gallery  a > img")
+      .should("have.attr", "src")
+      .and("include", "i.optimole.com");
   });
-  it('Elementor background image should be properly replaced', function () {
-    cy.get('.div-with-background .elementor-column-wrap ')
-      .should('have.css', 'background-image')
-      .and('include', 'i.optimole.com');
+  it("Elementor background image should be properly replaced", function () {
+    cy.get(".div-with-background .elementor-column-wrap ")
+      .should("have.css", "background-image")
+      .and("include", "i.optimole.com");
   });
 });

--- a/cypress/integration/test_elementor_background_lazyload.js
+++ b/cypress/integration/test_elementor_background_lazyload.js
@@ -1,55 +1,55 @@
-describe('Check Elementor Background Page', function () {
-  it('successfully loads', function () {
-    cy.visit('/elementor/');
+describe("Check Elementor Background Page", function () {
+  it("successfully loads", function () {
+    cy.visit("/elementor/");
   });
-  it('Elementor widgets should have background lazyloaded', function () {
-    cy.get('.elementor-inner')
-      .find('.elementor-widget-container')
+  it("Elementor widgets should have background lazyloaded", function () {
+    cy.get(".elementor-inner")
+      .find(".elementor-widget-container")
       .eq(0)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
-  it('Elementor widgets should have background lazyloaded', function () {
-    cy.get('.elementor-inner')
-      .find('.elementor-widget-container')
+  it("Elementor widgets should have background lazyloaded", function () {
+    cy.get(".elementor-inner")
+      .find(".elementor-widget-container")
       .eq(1)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
-  it('Elementor widgets  image not in view should have no background', function () {
-    cy.get('.elementor-inner')
-      .find('.elementor-widget-container')
+  it("Elementor widgets  image not in view should have no background", function () {
+    cy.get(".elementor-inner")
+      .find(".elementor-widget-container")
       .eq(3)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('Elementor background images should have background lazyloaded', function () {
-    cy.get('.elementor-inner')
-      .find('.elementor-background-overlay')
+  it("Elementor background images should have background lazyloaded", function () {
+    cy.get(".elementor-inner")
+      .find(".elementor-background-overlay")
       .eq(0)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
-  it('Elementor background image not in view should have no background', function () {
-    cy.get('.elementor-inner')
-      .find('.elementor-background-overlay')
+  it("Elementor background image not in view should have no background", function () {
+    cy.get(".elementor-inner")
+      .find(".elementor-background-overlay")
       .eq(1)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('After scroll the background images that come in view should be loaded', function () {
+  it("After scroll the background images that come in view should be loaded", function () {
     cy.scrollTo(0, 3650);
 
-    cy.get('.elementor-inner')
-      .find('.elementor-background-overlay')
+    cy.get(".elementor-inner")
+      .find(".elementor-background-overlay")
       .eq(1)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
 
-    cy.get('.elementor-inner')
-      .find('.elementor-widget-container')
+    cy.get(".elementor-inner")
+      .find(".elementor-widget-container")
       .eq(3)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
 });

--- a/cypress/integration/test_envira.js
+++ b/cypress/integration/test_envira.js
@@ -1,32 +1,34 @@
-describe('Check envira page', function () {
-  it('successfully loads', function () {
-    cy.visit('/envira-test-page/');
+describe("Check envira page", function () {
+  it("successfully loads", function () {
+    cy.visit("/envira-test-page/");
   });
-  it('Gallery images all attributes replaced properly', function () {
-    cy.get('#envira-gallery-wrap-92 .envira-gallery-image')
-      .should('have.attr', 'src')
-      .and('contain', 'i.optimole.com');
-    cy.get('#envira-gallery-wrap-92 .envira-gallery-image')
-      .should('have.attr', 'data-envira-src')
-      .and('contain', 'i.optimole.com');
-    cy.get('#envira-gallery-wrap-92 .envira-gallery-image')
-      .should('have.attr', 'data-envira-srcset')
-      .and('contain', 'i.optimole.com');
+  it("Gallery images all attributes replaced properly", function () {
+    cy.get("#envira-gallery-wrap-92 .envira-gallery-image")
+      .should("have.attr", "src")
+      .and("contain", "i.optimole.com");
+    cy.get("#envira-gallery-wrap-92 .envira-gallery-image")
+      .should("have.attr", "data-envira-src")
+      .and("contain", "i.optimole.com");
+    cy.get("#envira-gallery-wrap-92 .envira-gallery-image")
+      .should("have.attr", "data-envira-srcset")
+      .and("contain", "i.optimole.com");
 
-    cy.get('#envira-gallery-wrap-97 .envira-gallery-image')
-      .should('have.attr', 'data-safe-src')
-      .and('contain', 'i.optimole.com');
+    cy.get("#envira-gallery-wrap-97 .envira-gallery-image")
+      .should("have.attr", "data-safe-src")
+      .and("contain", "i.optimole.com");
 
-    cy.get('.envira-gallery-link').should('have.attr', 'href').and('contain', 'i.optimole.com');
-  });
-
-  it('Gallery images should never have lazyload on', function () {
-    cy.get('.envira-gallery-image').not('have.attr', 'data-opt-src');
+    cy.get(".envira-gallery-link")
+      .should("have.attr", "href")
+      .and("contain", "i.optimole.com");
   });
 
-  it('Gallery should have proper crop', function () {
-    cy.get('#envira-gallery-wrap-98 img')
-      .should('have.attr', 'data-envira-src')
-      .and('contain', 'rt:fill');
+  it("Gallery images should never have lazyload on", function () {
+    cy.get(".envira-gallery-image").not("have.attr", "data-opt-src");
+  });
+
+  it("Gallery should have proper crop", function () {
+    cy.get("#envira-gallery-wrap-98 img")
+      .should("have.attr", "data-envira-src")
+      .and("contain", "rt:fill");
   });
 });

--- a/cypress/integration/test_foo.js
+++ b/cypress/integration/test_foo.js
@@ -1,12 +1,14 @@
-describe('Check envira page', function () {
-  it('successfully loads', function () {
-    cy.visit('/foo-gallery/');
+describe("Check envira page", function () {
+  it("successfully loads", function () {
+    cy.visit("/foo-gallery/");
   });
-  it('Gallery images all attributes replaced properly', function () {
-    cy.get('.foogallery img').should('have.attr', 'data-src-fg').and('contain', 'i.optimole.com');
+  it("Gallery images all attributes replaced properly", function () {
+    cy.get(".foogallery img")
+      .should("have.attr", "data-src-fg")
+      .and("contain", "i.optimole.com");
   });
 
-  it('Gallery images should never have lazyload on', function () {
-    cy.get('.foogallery img').not('have.attr', 'data-opt-src');
+  it("Gallery images should never have lazyload on", function () {
+    cy.get(".foogallery img").not("have.attr", "data-opt-src");
   });
 });

--- a/cypress/integration/test_gif.js
+++ b/cypress/integration/test_gif.js
@@ -1,38 +1,48 @@
 // Added as per. https://docs.cypress.io/api/events/catalog-of-events.html#Uncaught-Exceptions
 // https://docs.cypress.io/guides/references/error-messages.html#Uncaught-exceptions-from-your-application
-Cypress.on('uncaught:exception', () => {
+Cypress.on("uncaught:exception", () => {
   // returning false here prevents Cypress from
   // failing the test
   return false;
 });
 
-describe('Check gif page', function () {
-  it('successfully loads', function () {
-    cy.visit('/no-builder/testing-gif-with-video/');
+describe("Check gif page", function () {
+  it("successfully loads", function () {
+    cy.visit("/no-builder/testing-gif-with-video/");
   });
-  const nativeLazy = 'loading' in HTMLImageElement.prototype;
-  it('Gallery images all attributes replaced properly', function () {
-    cy.get('video').should('have.attr', 'autoplay').and('contain', '');
-    cy.get('video').should('have.attr', 'muted').and('contain', '');
-    cy.get('video').should('have.attr', 'loop').and('contain', '');
-    cy.get('video').should('have.attr', 'playsinline').and('contain', '');
-    cy.get('video').should('have.attr', 'poster').and('contain', 'i.optimole.com');
-    cy.get('video').should('have.attr', 'poster').and('contain', 'q:eco');
-    cy.get('video').should('have.attr', 'original-src').and('contain', 'i.optimole.com');
-    cy.get('video > source').should('have.attr', 'src').and('contain', 'f:mp4');
-    cy.get('video > source').should('have.attr', 'src').and('contain', 'i.optimole.com');
-    cy.get('video > source').should('have.attr', 'type').and('contain', 'video/mp4');
+  const nativeLazy = "loading" in HTMLImageElement.prototype;
+  it("Gallery images all attributes replaced properly", function () {
+    cy.get("video").should("have.attr", "autoplay").and("contain", "");
+    cy.get("video").should("have.attr", "muted").and("contain", "");
+    cy.get("video").should("have.attr", "loop").and("contain", "");
+    cy.get("video").should("have.attr", "playsinline").and("contain", "");
+    cy.get("video")
+      .should("have.attr", "poster")
+      .and("contain", "i.optimole.com");
+    cy.get("video").should("have.attr", "poster").and("contain", "q:eco");
+    cy.get("video")
+      .should("have.attr", "original-src")
+      .and("contain", "i.optimole.com");
+    cy.get("video > source").should("have.attr", "src").and("contain", "f:mp4");
+    cy.get("video > source")
+      .should("have.attr", "src")
+      .and("contain", "i.optimole.com");
+    cy.get("video > source")
+      .should("have.attr", "type")
+      .and("contain", "video/mp4");
   });
-  it('successfully loads', function () {
-    cy.visit('/gif-test/');
+  it("successfully loads", function () {
+    cy.visit("/gif-test/");
   });
-  it('Images with gifs has proper tags', function () {
+  it("Images with gifs has proper tags", function () {
     if (nativeLazy) {
       this.skip();
     }
-    cy.get('.wp-block-image img').should('have.attr', 'src').and('include', 'data:image/svg+xml');
-    cy.get('.wp-block-image img')
-      .should('have.attr', 'data-opt-src')
-      .and('include', 'i.optimole.com');
+    cy.get(".wp-block-image img")
+      .should("have.attr", "src")
+      .and("include", "data:image/svg+xml");
+    cy.get(".wp-block-image img")
+      .should("have.attr", "data-opt-src")
+      .and("include", "i.optimole.com");
   });
 });

--- a/cypress/integration/test_gutenberg.js
+++ b/cypress/integration/test_gutenberg.js
@@ -1,29 +1,31 @@
-describe('Check gutenberg page', function () {
-  it('successfully loads', function () {
-    cy.visit('/gutenberg');
+describe("Check gutenberg page", function () {
+  it("successfully loads", function () {
+    cy.visit("/gutenberg");
   });
-  const nativeLazy = 'loading' in HTMLImageElement.prototype;
-  it('Gutenberg images should have replaced srcs', function () {
-    cy.get('.wp-block-image > img').should('have.attr', 'src').and('include', 'i.optimole.com');
+  const nativeLazy = "loading" in HTMLImageElement.prototype;
+  it("Gutenberg images should have replaced srcs", function () {
+    cy.get(".wp-block-image > img")
+      .should("have.attr", "src")
+      .and("include", "i.optimole.com");
   });
-  it('Gutenberg images should data-opt-src attribute', function () {
+  it("Gutenberg images should data-opt-src attribute", function () {
     if (nativeLazy) {
       this.skip();
     }
-    cy.get('.wp-block-image > img')
-      .should('have.attr', 'data-opt-src')
-      .and('include', 'i.optimole.com');
+    cy.get(".wp-block-image > img")
+      .should("have.attr", "data-opt-src")
+      .and("include", "i.optimole.com");
   });
-  it('Gutenberg images should have no script tag', function () {
-    cy.get('.wp-block-image > noscript').should('exist');
-    cy.get('.wp-block-image > noscript')
-      .should('contain', 'img')
-      .should('contain', 'i.optimole.com');
+  it("Gutenberg images should have no script tag", function () {
+    cy.get(".wp-block-image > noscript").should("exist");
+    cy.get(".wp-block-image > noscript")
+      .should("contain", "img")
+      .should("contain", "i.optimole.com");
   });
-  it('Gutenberg block cover background image should be properly replaced', function () {
-    cy.get('.wp-block-cover ')
+  it("Gutenberg block cover background image should be properly replaced", function () {
+    cy.get(".wp-block-cover ")
       .scrollIntoView()
-      .should('have.css', 'background-image')
-      .and('include', 'i.optimole.com');
+      .should("have.css", "background-image")
+      .and("include", "i.optimole.com");
   });
 });

--- a/cypress/integration/test_metaslider_background_lazyload.js
+++ b/cypress/integration/test_metaslider_background_lazyload.js
@@ -1,41 +1,41 @@
-describe('Check Metaslider Background Page', function () {
-  it('successfully loads', function () {
-    cy.visit('/metaslider/');
+describe("Check Metaslider Background Page", function () {
+  it("successfully loads", function () {
+    cy.visit("/metaslider/");
   });
-  it('Slider background images in view should be lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.coin-slider > .coin-slider')
+  it("Slider background images in view should be lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".coin-slider > .coin-slider")
       .eq(0)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
-  it('Slider background images in view should be lazyloaded', function () {
+  it("Slider background images in view should be lazyloaded", function () {
     for (let i = 4; i <= 30; i++) {
-      cy.get('.entry-content')
-        .find('.coin-slider > .coin-slider > a')
+      cy.get(".entry-content")
+        .find(".coin-slider > .coin-slider > a")
         .eq(i)
-        .should('have.attr', 'class')
-        .and('include', 'optml-bg-lazyloaded');
+        .should("have.attr", "class")
+        .and("include", "optml-bg-lazyloaded");
     }
   });
 
-  it('Scroll the page', function () {
+  it("Scroll the page", function () {
     cy.scrollTo(0, 2500);
   });
-  it('After scroll slider background images not in view should be lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.coin-slider > .coin-slider')
+  it("After scroll slider background images not in view should be lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".coin-slider > .coin-slider")
       .eq(1)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('After scroll slider background images not in view should be lazyloaded', function () {
+  it("After scroll slider background images not in view should be lazyloaded", function () {
     for (let i = 35; i <= 67; i++) {
-      cy.get('.entry-content')
-        .find('.coin-slider > .coin-slider > a')
+      cy.get(".entry-content")
+        .find(".coin-slider > .coin-slider > a")
         .eq(i)
-        .should('have.css', 'background-image')
-        .and('match', /none/);
+        .should("have.css", "background-image")
+        .and("match", /none/);
     }
   });
 });

--- a/cypress/integration/test_ss_pintereset.js
+++ b/cypress/integration/test_ss_pintereset.js
@@ -1,17 +1,19 @@
-describe('Sassy Social Share', function () {
-  it('successfully loads', function () {
-    cy.visit('/sassy-social-share/');
+describe("Sassy Social Share", function () {
+  it("successfully loads", function () {
+    cy.visit("/sassy-social-share/");
   });
-  it('click on button', function () {
-    cy.get('.heateorSssSharing.heateorSssPinterestBackground').click({ multiple: true });
+  it("click on button", function () {
+    cy.get(".heateorSssSharing.heateorSssPinterestBackground").click({
+      multiple: true,
+    });
   });
-  it('images should not have quality:eco', function () {
-    cy.get('img').should(($imgs) => {
+  it("images should not have quality:eco", function () {
+    cy.get("img").should(($imgs) => {
       expect($imgs).to.have.length(5);
-      expect($imgs.eq(0)).to.have.attr('src').and.to.not.contain('eco');
-      expect($imgs.eq(1)).to.have.attr('src').and.to.not.contain('eco');
-      expect($imgs.eq(2)).to.have.attr('src').and.to.not.contain('eco');
-      expect($imgs.eq(3)).to.have.attr('src').and.to.not.contain('eco');
+      expect($imgs.eq(0)).to.have.attr("src").and.to.not.contain("eco");
+      expect($imgs.eq(1)).to.have.attr("src").and.to.not.contain("eco");
+      expect($imgs.eq(2)).to.have.attr("src").and.to.not.contain("eco");
+      expect($imgs.eq(3)).to.have.attr("src").and.to.not.contain("eco");
     });
   });
 });

--- a/cypress/integration/test_su.js
+++ b/cypress/integration/test_su.js
@@ -1,23 +1,23 @@
-describe('Check Shortcode ultimate page', function () {
-  it('successfully loads', function () {
-    cy.visit('/blog/test/');
+describe("Check Shortcode ultimate page", function () {
+  it("successfully loads", function () {
+    cy.visit("/blog/test/");
   });
-  it('Carousel should have proper resize type', function () {
-    cy.get('.su-carousel-slide img')
-      .should('have.attr', 'data-opt-src')
-      .and('include', 'i.optimole.com')
-      .and('include', 'rt:fill');
+  it("Carousel should have proper resize type", function () {
+    cy.get(".su-carousel-slide img")
+      .should("have.attr", "data-opt-src")
+      .and("include", "i.optimole.com")
+      .and("include", "rt:fill");
   });
-  it('Slider should have proper resize type', function () {
-    cy.get('.su-slider img')
-      .should('have.attr', 'data-opt-src')
-      .and('include', 'i.optimole.com')
-      .and('include', 'rt:fill');
+  it("Slider should have proper resize type", function () {
+    cy.get(".su-slider img")
+      .should("have.attr", "data-opt-src")
+      .and("include", "i.optimole.com")
+      .and("include", "rt:fill");
   });
-  it('Gallery should have proper resize type', function () {
-    cy.get('.su-custom-gallery img')
-      .should('have.attr', 'data-opt-src')
-      .and('include', 'i.optimole.com')
-      .and('include', 'rt:fill');
+  it("Gallery should have proper resize type", function () {
+    cy.get(".su-custom-gallery img")
+      .should("have.attr", "data-opt-src")
+      .and("include", "i.optimole.com")
+      .and("include", "rt:fill");
   });
 });

--- a/cypress/integration/test_thrive_background_lazyload.js
+++ b/cypress/integration/test_thrive_background_lazyload.js
@@ -1,69 +1,69 @@
-describe('Check Thrive Background Page', function () {
-  it('successfully loads', function () {
-    cy.visit('/thrive/');
+describe("Check Thrive Background Page", function () {
+  it("successfully loads", function () {
+    cy.visit("/thrive/");
   });
-  it('tve-content-box-background that is in view should have optml-bg-lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.tve-content-box-background')
+  it("tve-content-box-background that is in view should have optml-bg-lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".tve-content-box-background")
       .eq(0)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
 
-  it('thrv_text_element that is in view should have optml-bg-lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.thrv_text_element')
+  it("thrv_text_element that is in view should have optml-bg-lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".thrv_text_element")
       .eq(0)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
-  it('tve-page-section-out that is in view should have optml-bg-lazyloaded', function () {
-    cy.get('.entry-content')
-      .find('.tve-page-section-out')
+  it("tve-page-section-out that is in view should have optml-bg-lazyloaded", function () {
+    cy.get(".entry-content")
+      .find(".tve-page-section-out")
       .eq(0)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
-  it('tve-content-box-background that is not in view should have background nonde', function () {
-    cy.get('.entry-content')
-      .find('.tve-content-box-background')
+  it("tve-content-box-background that is not in view should have background nonde", function () {
+    cy.get(".entry-content")
+      .find(".tve-content-box-background")
       .eq(1)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('tve-page-section-out that is not in view should have background nonde', function () {
-    cy.get('.entry-content')
-      .find('.tve-page-section-out')
+  it("tve-page-section-out that is not in view should have background nonde", function () {
+    cy.get(".entry-content")
+      .find(".tve-page-section-out")
       .eq(1)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('thrv_text_element that is not in view should have background nonde', function () {
-    cy.get('.entry-content')
-      .find('.thrv_text_element')
+  it("thrv_text_element that is not in view should have background nonde", function () {
+    cy.get(".entry-content")
+      .find(".thrv_text_element")
       .eq(2)
-      .should('have.css', 'background-image')
-      .and('match', /none/);
+      .should("have.css", "background-image")
+      .and("match", /none/);
   });
-  it('After scroll the background images that come in view should be loaded', function () {
+  it("After scroll the background images that come in view should be loaded", function () {
     cy.scrollTo(0, 3000);
 
-    cy.get('.entry-content')
-      .find('.tve-content-box-background')
+    cy.get(".entry-content")
+      .find(".tve-content-box-background")
       .eq(1)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
 
-    cy.get('.entry-content')
-      .find('.tve-page-section-out')
+    cy.get(".entry-content")
+      .find(".tve-page-section-out")
       .eq(1)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
 
-    cy.get('.entry-content')
-      .find('.thrv_text_element')
+    cy.get(".entry-content")
+      .find(".thrv_text_element")
       .eq(2)
-      .should('have.attr', 'class')
-      .and('include', 'optml-bg-lazyloaded');
+      .should("have.attr", "class")
+      .and("include", "optml-bg-lazyloaded");
   });
 });

--- a/cypress/integration/test_woo.js
+++ b/cypress/integration/test_woo.js
@@ -1,52 +1,54 @@
-Cypress.on('uncaught:exception', (err) => {
-  if (err.message.includes('event.target.matches is not a function')) {
+Cypress.on("uncaught:exception", (err) => {
+  if (err.message.includes("event.target.matches is not a function")) {
     return false;
   }
 });
-describe('Check product page', function () {
-  it('successfully loads', function () {
-    cy.visit('/product/test-product/');
+describe("Check product page", function () {
+  it("successfully loads", function () {
+    cy.visit("/product/test-product/");
   });
-  it('Gallery wrapper should have proper data-thumb', function () {
-    cy.get('.woocommerce-product-gallery__wrapper > div')
-      .should('have.attr', 'data-thumb')
-      .and('include', 'i.optimole.com');
+  it("Gallery wrapper should have proper data-thumb", function () {
+    cy.get(".woocommerce-product-gallery__wrapper > div")
+      .should("have.attr", "data-thumb")
+      .and("include", "i.optimole.com");
   });
-  it('Gallery wrapper link should have auto sizes', function () {
-    cy.get('.woocommerce-product-gallery__wrapper > div > a')
-      .should('have.attr', 'href')
-      .and('include', 'i.optimole.com')
-      .and('include', 'w:auto/h:auto');
+  it("Gallery wrapper link should have auto sizes", function () {
+    cy.get(".woocommerce-product-gallery__wrapper > div > a")
+      .should("have.attr", "href")
+      .and("include", "i.optimole.com")
+      .and("include", "w:auto/h:auto");
   });
-  it('Gallery wrapper image from link should have proper images', function () {
-    cy.get('.woocommerce-product-gallery__wrapper > div > a > img')
-      .should('have.attr', 'src')
-      .and('include', 'i.optimole.com');
-    cy.get('.woocommerce-product-gallery__wrapper > div > a > img')
-      .should('have.attr', 'data-src')
-      .and('include', 'i.optimole.com');
-    cy.get('.woocommerce-product-gallery__wrapper > div > a > img')
-      .should('have.attr', 'data-large_image')
-      .and('include', 'i.optimole.com');
+  it("Gallery wrapper image from link should have proper images", function () {
+    cy.get(".woocommerce-product-gallery__wrapper > div > a > img")
+      .should("have.attr", "src")
+      .and("include", "i.optimole.com");
+    cy.get(".woocommerce-product-gallery__wrapper > div > a > img")
+      .should("have.attr", "data-src")
+      .and("include", "i.optimole.com");
+    cy.get(".woocommerce-product-gallery__wrapper > div > a > img")
+      .should("have.attr", "data-large_image")
+      .and("include", "i.optimole.com");
   });
-  it('Zoom img should have auto size', function () {
-    cy.get('.woocommerce-product-gallery__wrapper .zoomImg')
-      .should('have.attr', 'src')
-      .and('include', 'i.optimole.com')
-      .and('include', 'w:auto/h:auto');
+  it("Zoom img should have auto size", function () {
+    cy.get(".woocommerce-product-gallery__wrapper .zoomImg")
+      .should("have.attr", "src")
+      .and("include", "i.optimole.com")
+      .and("include", "w:auto/h:auto");
   });
-  it('All images should have proper tags', function () {
-    cy.get('img:not(.emoji)').should('have.attr', 'src').and('include', 'i.optimole.com');
+  it("All images should have proper tags", function () {
+    cy.get("img:not(.emoji)")
+      .should("have.attr", "src")
+      .and("include", "i.optimole.com");
   });
 });
-describe('Test quick view', function () {
-  it('successfully loads', function () {
-    cy.visit('/shop');
-    cy.get('.yith-wcqv-button:first').click();
+describe("Test quick view", function () {
+  it("successfully loads", function () {
+    cy.visit("/shop");
+    cy.get(".yith-wcqv-button:first").click();
   });
-  it('Quick view have optimole images', function () {
-    cy.get('#yith-quick-view-content .woocommerce-product-gallery__wrapper img')
-      .should('have.attr', 'src')
-      .and('include', 'i.optimole.com');
+  it("Quick view have optimole images", function () {
+    cy.get("#yith-quick-view-content .woocommerce-product-gallery__wrapper img")
+      .should("have.attr", "src")
+      .and("include", "i.optimole.com");
   });
 });


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
 - ESLint was added with Prettier to enforce code style and enables checking before commit.


### How to test the changes in this Pull Request:

1. ESLint should run according to the rules inside the Cypress folder
