### PR TITLE
chore: updated elementor background lazyload classes

### DIFF
--- a/cypress/integration/test_elementor_background_lazyload.js
+++ b/cypress/integration/test_elementor_background_lazyload.js
@@ -9,6 +9,13 @@ describe("Check Elementor Background Page", function () {
       .should("have.attr", "class")
       .and("include", "optml-bg-lazyloaded");
   });
+  it("Elementor widgets should have background image url optimized (ie. external css is processed)", function () {
+    cy.get(".elementor-inner")
+      .find(".elementor-widget-container")
+      .eq(0)
+      .should("have.css", "background-image")
+      .and("match", /url\(.*\.i\.optimole\.com.*\)/);
+  });
   it("Elementor widgets should have background lazyloaded", function () {
     cy.get(".elementor-inner")
       .find(".elementor-widget-container")
@@ -19,7 +26,7 @@ describe("Check Elementor Background Page", function () {
   it("Elementor widgets  image not in view should have no background", function () {
     cy.get(".elementor-inner")
       .find(".elementor-widget-container")
-      .eq(3)
+      .eq(4)
       .should("have.css", "background-image")
       .and("match", /none/);
   });
@@ -37,8 +44,27 @@ describe("Check Elementor Background Page", function () {
       .should("have.css", "background-image")
       .and("match", /none/);
   });
+  it("Elementor background gallery item image that is in view should have background lazyloaded", function () {
+    cy.scrollTo(0, 200);
+    for (let i = 0; i < 6; i++) {
+      cy.get(".elementor-inner")
+        .find(".elementor-background-slideshow__slide__image")
+        .eq(i)
+        .should("have.attr", "class")
+        .and("include", "optml-bg-lazyloaded");
+    }
+  });
+  it("Elementor background gallery item image that is not in view should have no background", function () {
+    for (let i = 6; i < 12; i++) {
+      cy.get(".elementor-inner")
+        .find(".elementor-background-slideshow__slide__image")
+        .eq(i)
+        .should("have.css", "background-image")
+        .and("match", /none/);
+    }
+  });
   it("After scroll the background images that come in view should be loaded", function () {
-    cy.scrollTo(0, 3650);
+    cy.scrollTo(200, 4100);
 
     cy.get(".elementor-inner")
       .find(".elementor-background-overlay")
@@ -48,8 +74,16 @@ describe("Check Elementor Background Page", function () {
 
     cy.get(".elementor-inner")
       .find(".elementor-widget-container")
-      .eq(3)
+      .eq(4)
       .should("have.attr", "class")
       .and("include", "optml-bg-lazyloaded");
+
+    for (let i = 6; i < 12; i++) {
+      cy.get(".elementor-inner")
+        .find(".elementor-background-slideshow__slide__image")
+        .eq(i)
+        .should("have.attr", "class")
+        .and("include", "optml-bg-lazyloaded");
+    }
   });
 });

--- a/inc/compatibilities/elementor_builder.php
+++ b/inc/compatibilities/elementor_builder.php
@@ -27,6 +27,7 @@ class Optml_elementor_builder extends Optml_compatibility {
 			'optml_lazyload_bg_selectors',
 			function ( $all_watchers ) {
 				$all_watchers[] = '.elementor-widget-container';
+				$all_watchers[] = '.elementor-background-slideshow__slide__image';
 				return $all_watchers;
 			}
 		);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "pre-e2e": "npm run prebuild",
     "cypress:open": "cypress open",
     "cypress:run": "cd cypress && docker-compose up --exit-code-from cypress",
+    "cypress:lint" : "cd cypress && eslint --fix .",
     "dist": "./bin/dist.sh",
     "build": "npm run prebuild"
   },


### PR DESCRIPTION
Fixes #331 . 

There is only one more way to add background that was not covered by the previous compatiblity (the previous classes are working as before). The css replacement works the same in this version. 

For testing I think I can update the current elementor version on testing.optimole.com and include the new background in the cypress test ?
 
