### PR TITLE
fix: added extra padding for no js class

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -162,7 +162,10 @@ class Optml_Admin {
 	 * @return array
 	 */
 	public function add_no_js_class_to_html_tag( $classes ) {
-		return array_merge( $classes, [ 'optml_no_js' ] );
+	    // we need the space padding since some plugins might not target correctly with js there own classes
+        // this causes some issues if they concat directly, this way we can protect against that since no matter what
+        // there will be an extra space padding so that classes can be easily identified
+		return array_merge( $classes, [ ' optml_no_js ' ] );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -45,7 +45,7 @@ Better yet. The free version is fully functional and includes all of the followi
 **Format Based Optimization**
 Our cloud-based transformation process means we can optimize images based on the format as well as serve images in next-gen formats. If your visitor is using a WebP capable browser, then Optimole will convert to WebP the image and send it to their device.
 
-**Cloud Library support*
+**Cloud Library support**
 Offload your website images directly to Optimole Cloud and save storage space on your server. Cross share images between your all your websites connected to Optimole.
 
 **Image Optimization**


### PR DESCRIPTION
This is just a small fix. There are cases when a theme or a plugin will add it's own no-js classes but does not respect the WordPress way of adding them, hence they might get glued to our class. Eg. `optml_no_jsplugin_no_js` instead of. `optml_no_js plugin_no_js` it does not affect the way our plugin works but it might break the no-js functionality of other plugins.

This should improve compatibility.
