### PR TITLE
chore: fix woocommerce product page lazyload conflict

### DIFF
--- a/inc/compatibilities/woocommerce.php
+++ b/inc/compatibilities/woocommerce.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Class Optml_elementor_builder
+ *
+ * @reason Adding selectors for background lazyload
+ */
+class Optml_woocommerce extends Optml_compatibility {
+
+
+	/**
+	 * Should we load the integration logic.
+	 *
+	 * @return bool Should we load.
+	 */
+	function should_load() {
+		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+		return Optml_Main::instance()->admin->settings->use_lazyload() && is_plugin_active( 'woocommerce/woocommerce.php' );
+	}
+
+	/**
+	 * Register integration details.
+	 */
+	public function register() {
+		add_filter( 'optml_should_ignore_image_tags', [$this, 'check_product_page'], 10, 1 );
+	}
+	/**
+	 * Add ignore page lazyload flag.
+	 *
+	 * @param bool $old_value Previous returned value.
+	 *
+	 * @return bool If we should lazyload the page.
+	 */
+	public function check_product_page( $old_value ) {
+		if ( is_product() ) {
+			return true;
+		}
+		return $old_value;
+	}
+}

--- a/inc/manager.php
+++ b/inc/manager.php
@@ -76,6 +76,7 @@ final class Optml_Manager {
 		'w3_total_cache',
 		'translate_press',
 		'give_wp',
+		'woocommerce',
 		'smart_search_woocommerce',
 	];
 	/**


### PR DESCRIPTION
Fixes #366 ( I was not able to replicate the issue ) and also fixes some other issue that I found while testing: when picking a different image from a product gallery it is blurry because we use the smaller size https://vertis.d.pr/oTxVnf . ( happens when using thumbnail size for the product gallery for example )