### PR TITLE
chore: fixed % sizes parsed as actual size

### DIFF
--- a/inc/tag_replacer.php
+++ b/inc/tag_replacer.php
@@ -263,10 +263,14 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 	 */
 	private function parse_dimensions_from_tag( $tag, $image_sizes, $args = [] ) {
 		if ( preg_match( '#width=["|\']?([\d%]+)["|\']?#i', $tag, $width_string ) ) {
-			$args['width'] = $width_string[1];
+			if ( strpos($args['width'], "%") === false  ) {
+				$args['width'] = $width_string[1];
+			}
 		}
 		if ( preg_match( '#height=["|\']?([\d%]+)["|\']?#i', $tag, $height_string ) ) {
-			$args['height'] = $height_string[1];
+			if ( strpos($args['width'], "%") === false  ) {
+				$args['height'] = $height_string[1];
+			}
 		}
 		if ( preg_match( '#class=["|\']?[^"\']*size-([^"\'\s]+)[^"\']*["|\']?#i', $tag, $size ) ) {
 			$size = array_pop( $size );


### PR DESCRIPTION
Right now we parse tags like this and we add the width as number: 

<img decoding="async" src="https://optm.com/w:100/h:auto/q:mauto/f:avif/http://optimoletest.test/wp-content/uploads/2022/08/fezbot2000-nahUo1GhcrA-unsplash.jpg" alt="" class="wp-image-347" width="100%">
 
Not sure if this is the best fix, I'll use it temporary to share the build with the user until we look closer.