### PR TITLE
chore: fixed media offload page flag issues

### DIFF
--- a/inc/compatibilities/woocommerce.php
+++ b/inc/compatibilities/woocommerce.php
@@ -26,9 +26,6 @@ class Optml_woocommerce extends Optml_compatibility {
 			add_filter( 'optml_possible_lazyload_flags', [ $this, 'add_ignore_lazyload' ], PHP_INT_MAX, 1 );
 		}
 
-		if ( Optml_Main::instance()->admin->settings->get( 'offload_media' ) === 'enabled' ) {
-			add_filter( 'optml_offload_images_post_parents', [ $this, 'add_product_pages_to_image_query' ], PHP_INT_MAX, 1 );
-		}
 	}
 	/**
 	 * Add ignore lazyload flag.

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -68,6 +68,12 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 	 * @var string Used when moving the file to our servers.
 	 */
 	private static $last_deduplicated_original;
+	/**
+	 * Checks if the plugin was installed before adding POST_OFFLOADED_FLAG.
+	 *
+	 * @var bool Used when applying the flags for the page query.
+	 */
+	private static $is_legacy_install = null;
 
 	/**
 	 * Adds page meta query args
@@ -94,7 +100,7 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 					'compare' => 'NOT EXISTS',
 				],
 			];
-			if ( get_option( 'optimole_wp_install', 0 ) > 1666123200 ) {
+			if ( self::$is_legacy_install ) {
 				$args['meta_query'][] = [
 					'key' => self::POST_OFFLOADED_FLAG,
 					'value' => 'true',
@@ -256,6 +262,10 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 				add_filter( 'wp_calculate_image_srcset', [self::$instance, 'calculate_image_srcset'], 1, 5 );
 				add_action( 'post_updated', [self::$instance, 'update_offload_meta'], 10, 3 );
 				add_filter( 'wp_insert_attachment_data', [self::$instance, 'insert'], 10, 4 );
+
+				if ( self::$is_legacy_install === null ) {
+					self::$is_legacy_install = get_option( 'optimole_wp_install', 0 ) > 1666123200;
+				}
 			}
 		}
 		return self::$instance;

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -68,6 +68,43 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 	 * @var string Used when moving the file to our servers.
 	 */
 	private static $last_deduplicated_original;
+
+	/**
+	 * Adds page meta query args
+	 *
+	 * @param string $action The action for which the args are needed
+	 * @param array  $args The initial args without the added meta_query args
+	 * @return array The args with the added meta_query args
+	 */
+	public static function add_page_meta_query_args( $action, $args ) {
+		if ( $action === 'offload_images' ) {
+			$args['meta_query'] = [
+				'relation' => 'AND',
+				[
+					'key' => self::POST_OFFLOADED_FLAG,
+					'compare' => 'NOT EXISTS',
+				],
+			];
+		}
+		if ( $action === 'rollback_images' ) {
+			$args['meta_query'] = [
+				'relation' => 'AND',
+				[
+					'key' => self::POST_ROLLBACK_FLAG,
+					'compare' => 'NOT EXISTS',
+				],
+			];
+			if ( get_option( 'optimole_wp_install', 0 ) > 1666123200 ) {
+				$args['meta_query'][] = [
+					'key' => self::POST_OFFLOADED_FLAG,
+					'value' => 'true',
+					'compare' => '=',
+				];
+			}
+		}
+		return $args;
+	}
+
 	/**
 	 * Enqueue script for generating cloud media tab.
 	 */
@@ -331,7 +368,6 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 		}
 
 		// revisions are skipped inside the function no need to check them before
-		delete_post_meta( $post_ID, self::POST_OFFLOADED_FLAG );
 		delete_post_meta( $post_ID, self::POST_ROLLBACK_FLAG );
 	}
 	/**
@@ -604,29 +640,7 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 				'update_post_term_cache' => false,
 			]
 		);
-		if ( $job === 'offload_images' ) {
-			$query_args['meta_query'] = [
-				'relation' => 'AND',
-				[
-					'key' => self::POST_OFFLOADED_FLAG,
-					'compare' => 'NOT EXISTS',
-				],
-			];
-		}
-		if ( $job === 'rollback_images' ) {
-			$query_args['meta_query'] = [
-				'relation' => 'AND',
-				[
-					'key' => self::POST_OFFLOADED_FLAG,
-					'value' => 'true',
-					'compare' => '=',
-				],
-				[
-					'key' => self::POST_ROLLBACK_FLAG,
-					'compare' => 'NOT EXISTS',
-				],
-			];
-		}
+		$query_args = self::add_page_meta_query_args( $job, $query_args );
 		$content = new \WP_Query( $query_args );
 		if ( OPTML_DEBUG_MEDIA ) {
 			do_action( 'optml_log', $page );
@@ -1307,6 +1321,13 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 		if ( OPTML_DEBUG_MEDIA ) {
 			do_action( 'optml_log', 'success offload' );
 		}
+		$attachment_page_id = wp_get_post_parent_id( $attachment_id );
+
+		if ( $attachment_page_id !== false && $attachment_page_id !== 0 ) {
+			self::$offload_update_post = true;
+			update_post_meta( $attachment_page_id, self::POST_OFFLOADED_FLAG, 'true' );
+			self::$offload_update_post = false;
+		}
 		return $meta;
 	}
 
@@ -1358,29 +1379,7 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 				return $args;
 			}
 		} else {
-			if ( $action === 'offload_images' ) {
-				$args['meta_query'] = [
-					'relation' => 'AND',
-					[
-						'key' => self::POST_OFFLOADED_FLAG,
-						'compare' => 'NOT EXISTS',
-					],
-				];
-			}
-			if ( $action === 'rollback_images' ) {
-				$args['meta_query'] = [
-					'relation' => 'AND',
-					[
-						'key' => self::POST_OFFLOADED_FLAG,
-						'value' => 'true',
-						'compare' => '=',
-					],
-					[
-						'key' => self::POST_ROLLBACK_FLAG,
-						'compare' => 'NOT EXISTS',
-					],
-				];
-			}
+			$args = self::add_page_meta_query_args( $action, $args );
 		}
 		$post_types = array_values(
 			array_filter(

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -1358,7 +1358,6 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 			$args ['post_type'] = 'attachment';
 			$args ['post_mime_type'] = 'image';
 			$args ['post_status'] = 'inherit';
-			$args['post_parent__in'] = apply_filters( 'optml_offload_images_post_parents', [ 0 ] );
 			if ( $action === 'offload_images' ) {
 				$args['meta_query'] = [
 					'relation' => 'AND',

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -72,9 +72,9 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 	/**
 	 * Adds page meta query args
 	 *
-	 * @param string $action The action for which the args are needed
-	 * @param array  $args The initial args without the added meta_query args
-	 * @return array The args with the added meta_query args
+	 * @param string $action The action for which the args are needed.
+	 * @param array  $args The initial args without the added meta_query args.
+	 * @return array The args with the added meta_query args.
 	 */
 	public static function add_page_meta_query_args( $action, $args ) {
 		if ( $action === 'offload_images' ) {


### PR DESCRIPTION
Fixes https://github.com/Codeinwp/optimole-service/issues/673 . 

Fixes https://github.com/Codeinwp/optimole-service/issues/674 .

Changes:

Uses `POST_OFFLOADED_FLAG` for queries only if the plugin was installed after the flag was added: https://github.com/Codeinwp/optimole-wp/releases/tag/v3.5.0 .

Updates page meta with the `POST_OFFLOADED_FLAG` when an images is uploaded directly into the page. 

Removes redundant(wrong) `POST_OFFLOADED_FLAG` removal on page update. 
