### PR TITLE
Fix/449

### DIFF
--- a/inc/lazyload_replacer.php
+++ b/inc/lazyload_replacer.php
@@ -323,8 +323,6 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 		$search = [];
 		$replace = [];
 		foreach ( $video_tags as $video_tag ) {
-			do_action( 'optml_log', 'here' );
-			do_action( 'optml_log', $video_tag );
 
 			if ( ! $this->should_lazyload_iframe( $video_tag ) ) {
 				continue;
@@ -482,7 +480,7 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 	 * @return bool Should add?
 	 */
 	public function should_lazyload_iframe( $tag ) {
-		do_action( 'optml_log', self::get_iframe_lazyload_flags() );
+
 		foreach ( self::get_iframe_lazyload_flags() as $banned_string ) {
 			if ( strpos( $tag, $banned_string ) !== false ) {
 				return false;

--- a/tests/test-lazyload.php
+++ b/tests/test-lazyload.php
@@ -22,7 +22,7 @@ class Test_Lazyload extends WP_UnitTestCase {
 	<img src="http://example.org/wp-content/plugins/optimole-wp/assets/img/logo2.JPE">
 	<img src="http://example.org/wp-content/plugins/optimole-wp/assets/img/logo3.WEBP">
 	<img src="http://example.org/wp-content/plugins/optimole-wp/assets/img/logo4.svg">
-	<img src="http://example.org/wp-content/plugins/optimole-wp/assets/img/logo5.gif">
+	<img src="http://example.org/wp-content/optimole-wp/assets/img/logo5.gif">
 	 ';
 	public function setUp() : void {
 		parent::setUp();

--- a/tests/test-video.php
+++ b/tests/test-video.php
@@ -23,7 +23,10 @@ class Test_Video_Tag extends WP_UnitTestCase {
                         <img src="https://www.example.org/wp-content/uploads/2018/05/placeholder.gif"/>
                         <img src="https://www.example.org/wp-content/uploads/2018/05/lazy_placeholder.gif"/>
                         <img src="https://www.example.org/wp-content/uploads/2018/05/plugin-placeholders/something.gif"/>
-
+                         <img src="https://www.example.org/wp-content/uploads/2018/05/plugins/something.gif"/>
+                         <img src="https://www.example.org/wp-content/uploads/2018/05/image.gif" width="10" height="15"/>
+                         <img src="https://www.example.org/wp-content/uploads/2018/05/plugins/something.gif" width="710" height="15"/>
+                         <img src="https://www.example.org/wp-content/uploads/2018/05/uploads/something17.gif" width="710" height="15"/>
                      </div>';
 
     public static $sample_post;


### PR DESCRIPTION
Fixes #449 . 

Excludes gifs from the `plugins` directory and gifs with `min(width, height) <=20` from lazyload and video conversion. 


For testing this we can have some gifs added and set the width, height from the editor below the limit, they should be optimized and not be lazyloaded or converted to video when the option is enabled.

The same should happend for gifs from the `plugins` directory. For those we do not need to have an actual gif uploaded in the plugins folder it is enough to insert the URL without the image to exist (eg: `http://optimoletest.test/wp-content/plugins/test-plugin/something.gif` and just check that the tag is not lazyloaded/converted. 

The gifs under these conditions should only be optimized like this https://vertis.d.pr/i/rKoaNs .
 
