### PR TITLE
disable e2e tests for PRs opened by dependabot

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -2,8 +2,6 @@ name: E2E Tests
 
 on:
   pull_request:
-    branches-ignore:
-      - 'dependabot/*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
@@ -13,7 +11,7 @@ env:
 
 jobs:
   e2e:
-    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: ( github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name ) && ( github.actor != 'dependabot[bot]' )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
branches-ignore param to ignore the target branch.

Therefore, I've filtered against Dependabot user.

ref: https://github.com/orgs/community/discussions/26079

Closes https://github.com/Codeinwp/themeisle/issues/1445