### PR TITLE
Add SVG support

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -43,6 +43,10 @@ class Optml_Admin {
 		}
 		add_action( 'optml_after_setup', [ $this, 'register_public_actions' ], 999999 );
 
+		if ( ! function_exists( 'is_wpcom_vip' ) ) {
+			add_filter( 'upload_mimes', [ $this, 'allow_meme_types' ] ); // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.upload_mimes
+			add_filter( 'wp_check_filetype_and_ext', [ $this, 'fix_mime_type_svg' ], 75, 4 );
+		}
 	}
 
 	/**
@@ -1058,4 +1062,42 @@ The root cause might be either a security plugin which blocks this feature or so
 		];
 	}
 
+	/**
+	 * Allow SVG uploads
+	 *
+	 * @param array $mimes Supported mimes.
+	 *
+	 * @return array
+	 * @access public
+	 */
+	public function allow_meme_types( $mimes ) {
+		$mimes['svg']  = 'image/svg+xml';
+		return $mimes;
+	}
+
+	/**
+	 * Allow JSON uploads
+	 *
+	 * @param null $data File data.
+	 * @param null $file File object.
+	 * @param null $filename File name.
+	 * @param null $mimes Supported mimes.
+	 *
+	 * @return array
+	 * @access public
+	 */
+	public function fix_mime_type_svg( $data = null, $file = null, $filename = null, $mimes = null ) {
+		$ext = isset( $data['ext'] ) ? $data['ext'] : '';
+
+		if ( 1 > strlen( $ext ) ) {
+			$exploded = explode( '.', $filename );
+			$ext      = strtolower( end( $exploded ) );
+		}
+
+		if ( 'svg' === $ext ) {
+			$data['type'] = 'image/svg+xml';
+			$data['ext']  = 'svg';
+		}
+		return $data;
+	}
 }

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -45,7 +45,6 @@ class Optml_Admin {
 
 		if ( ! function_exists( 'is_wpcom_vip' ) ) {
 			add_filter( 'upload_mimes', [ $this, 'allow_meme_types' ] ); // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.upload_mimes
-			add_filter( 'wp_check_filetype_and_ext', [ $this, 'fix_mime_type_svg' ], 75, 4 );
 		}
 	}
 
@@ -1069,35 +1068,10 @@ The root cause might be either a security plugin which blocks this feature or so
 	 *
 	 * @return array
 	 * @access public
+	 * @uses filter:upload_mimes
 	 */
 	public function allow_meme_types( $mimes ) {
 		$mimes['svg']  = 'image/svg+xml';
 		return $mimes;
-	}
-
-	/**
-	 * Allow SVG uploads
-	 *
-	 * @param null $data File data.
-	 * @param null $file File object.
-	 * @param null $filename File name.
-	 * @param null $mimes Supported mimes.
-	 *
-	 * @return array
-	 * @access public
-	 */
-	public function fix_mime_type_svg( $data = null, $file = null, $filename = null, $mimes = null ) {
-		$ext = isset( $data['ext'] ) ? $data['ext'] : '';
-
-		if ( 1 > strlen( $ext ) ) {
-			$exploded = explode( '.', $filename );
-			$ext      = strtolower( end( $exploded ) );
-		}
-
-		if ( 'svg' === $ext ) {
-			$data['type'] = 'image/svg+xml';
-			$data['ext']  = 'svg';
-		}
-		return $data;
 	}
 }

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1076,7 +1076,7 @@ The root cause might be either a security plugin which blocks this feature or so
 	}
 
 	/**
-	 * Allow JSON uploads
+	 * Allow SVG uploads
 	 *
 	 * @param null $data File data.
 	 * @param null $file File object.

--- a/tests/test-media.php
+++ b/tests/test-media.php
@@ -260,7 +260,6 @@ class Test_Media extends WP_UnitTestCase {
 	 */
 	public function test_svg_upload() : void {
 		self::$sample_attachement = self::factory()->attachment->create_upload_object( OPTML_PATH . 'assets/img/logo.svg' );
-		$content =  wp_get_attachment_image( self::$sample_attachement, 'full' );
-		$this->assertEquals( "<img src=\"http://example.org/wp-content/uploads/2023/03/logo-4.svg\" class=\"attachment-full size-full\" alt=\"\" decoding=\"async\" />", $content );
+		$this->assertTrue( file_exists( get_attached_file(self::$sample_attachement) ) );
 	}
 }

--- a/tests/test-media.php
+++ b/tests/test-media.php
@@ -255,4 +255,12 @@ class Test_Media extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * Test if the svg upload works.
+	 */
+	public function test_svg_upload() : void {
+		self::$sample_attachement = self::factory()->attachment->create_upload_object( OPTML_PATH . 'assets/img/logo.svg' );
+		$content =  wp_get_attachment_image( self::$sample_attachement, 'full' );
+		$this->assertEquals( "<img src=\"http://example.org/wp-content/uploads/2023/03/logo-4.svg\" class=\"attachment-full size-full\" alt=\"\" decoding=\"async\" />", $content );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
 This adds support to allow SVG uploads in WordPress.

Closes #13.

### How to test the changes in this Pull Request:

1. You can try to upload SVG file to a fresh WP with and without Optimole and see if it works or not.
2. With Optimole, it should allow SVG uploads, without it won'.t.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
