### PR TITLE
Fix SDK build files being ignored

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -32,7 +32,6 @@ logs
 grunt
 tests
 dist
-build
 artifact
 assets/vue
 .wporg


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
Quick investigation and the issue is for some reason the distignore contained `build` folder. Removing it keeps the SDK build files.

Closes #517 .

### How to test the changes in this Pull Request:

1. Run `npm run dist` and you will notice themeisle-sdk containing its build files.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
