### PR TITLE
Fixes

### DIFF
--- a/assets/vue/components/lazyload.vue
+++ b/assets/vue/components/lazyload.vue
@@ -11,12 +11,12 @@
 								<toggle-button :class="'has-text-dark'"
 															 v-model="lazyloadPlaceholder"
 															 :disabled="this.$store.state.loading"
-                               :width="37"
-                               :height="20"
-                               color="#577BF9"></toggle-button>
+															 :width="37"
+															 :height="20"
+															 color="#577BF9"></toggle-button>
 						</div>
 				</div>
-        <hr/>
+				<hr/>
 
 				<div class="field  columns optml-flex-column" >
 					<label class="label column optml-custom-label-margin">
@@ -35,7 +35,7 @@
 					</div>
 
 			</div>
-      <hr/>
+			<hr/>
 				<!--Native lazy toggle-->
 				<div class="field  is-fullwidth columns">
 						<label class="label column has-text-grey-dark optml-custom-label-margin">
@@ -50,12 +50,12 @@
 								<toggle-button :class="'has-text-dark'"
 															 v-model="nativeLazyStatus"
 															 :disabled="this.$store.state.loading"
-                               :width="37"
-                               :height="20"
-                               color="#577BF9"></toggle-button>
+															 :width="37"
+															 :height="20"
+															 color="#577BF9"></toggle-button>
 						</div>
 				</div>
-      <hr/>
+			<hr/>
 				<div class="field  is-fullwidth columns">
 						<label class="label column has-text-grey-dark optml-custom-label-margin">
 								{{strings.toggle_scale}}
@@ -69,12 +69,12 @@
 								<toggle-button :class="'has-text-dark'"
 															 v-model="scaleStatus"
 															 :disabled="this.$store.state.loading"
-                               :width="37"
-                               :height="20"
-                               color="#577BF9"></toggle-button>
+															 :width="37"
+															 :height="20"
+															 color="#577BF9"></toggle-button>
 						</div>
 				</div>
-      <hr/>
+			<hr/>
 				<div class="field columns">
 						<label class="label column has-text-grey-dark optml-custom-label-margin">
 								{{strings.enable_bg_lazyload_title}}
@@ -86,12 +86,12 @@
 								<toggle-button :class="'has-text-dark'"
 															 v-model="lazyloadBgImages"
 															 :disabled="this.$store.state.loading"
-                               :width="37"
-                               :height="20"
-                               color="#577BF9"></toggle-button>
+															 :width="37"
+															 :height="20"
+															 color="#577BF9"></toggle-button>
 						</div>
 				</div>
-      <hr/>
+			<hr/>
 				<!--Video lazyload toggle-->
 				<div class="field columns">
 						<label class="label column has-text-grey-dark optml-custom-label-margin">
@@ -104,12 +104,30 @@
 								<toggle-button :class="'has-text-dark'"
 															 v-model="lazyloadVideo"
 															 :disabled="this.$store.state.loading"
-                               :width="37"
-                               :height="20"
-                               color="#577BF9"></toggle-button>
+															 :width="37"
+															 :height="20"
+															 color="#577BF9"></toggle-button>
 						</div>
 				</div>
-      <hr/>
+			<hr/>
+			<!--Noscript toggle-->
+			<div class="field columns">
+				<label class="label column has-text-grey-dark optml-custom-label-margin">
+					{{strings.enable_noscript_title}}
+					<p class="optml-settings-desc-margin has-text-weight-normal">
+						{{strings.enable_noscript_desc}}
+					</p>
+				</label>
+				<div class="column is-1">
+					<toggle-button :class="'has-text-dark'"
+												 v-model="noscriptToggle"
+												 :disabled="this.$store.state.loading"
+												 :width="37"
+												 :height="20"
+												 color="#577BF9"></toggle-button>
+				</div>
+			</div>
+			<hr/>
 				<div class="field columns" v-if="showBgSelectors">
 						<div class="column">
 								<label class="label has-text-grey-dark optml-custom-label-margin">
@@ -198,6 +216,15 @@
 				},
 				get: function () {
 					return !(this.site_settings.video_lazyload === 'disabled');
+				}
+			},
+			noscriptToggle: {
+				set: function (value) {
+					this.showSave = true;
+					this.new_data.no_script = value ? 'enabled' : 'disabled';
+				},
+				get: function () {
+					return !(this.site_settings.no_script === 'disabled');
 				}
 			},
 			lazyloadSelectors: {

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -890,6 +890,8 @@ The root cause might be either a security plugin which blocks this feature or so
 				'enable_bg_lazyload_title'          => __( 'Enable lazyload for background images', 'optimole-wp' ),
 				'enable_video_lazyload_desc'        => __( 'Lazyload iframes/videos', 'optimole-wp' ),
 				'enable_video_lazyload_title'       => __( 'Enable lazyload for embedded videos and iframes.', 'optimole-wp' ),
+				'enable_noscript_desc'              => __( 'The noscript tag offers fallback images for browsers that can\'t handle JavaScript-based lazy loading or related features. Disabling it may resolve conflicts with other plugins or configurations and decrease HTML page size.', 'optimole-wp' ),
+				'enable_noscript_title'             => __( 'Enable noscript tag', 'optimole-wp' ),
 				'enable_gif_replace_title'          => __( 'Enable Gif to Video conversion', 'optimole-wp' ),
 				'enable_report_title'               => __( 'Enable error diagnosis tool', 'optimole-wp' ),
 				'enable_report_desc'                => __( 'Provides a troubleshooting mechanism which should help you identify any possible issues with your site using Optimole.', 'optimole-wp' ),

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -54,7 +54,8 @@ class Optml_Admin {
 	 */
 	public function init_no_script() {
 		if ( $this->settings->is_connected() ) {
-			if ( empty( $this->settings->get( 'no_script' ) ) ) {
+			$raw_settings = $this->settings->get_raw_settings();
+			if ( ! isset( $raw_settings['no_script'] ) ) {
 				$this->settings->update( 'no_script', 'enabled' );
 			}
 		}

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -38,6 +38,7 @@ class Optml_Admin {
 			add_action( 'init', [$this, 'check_domain_change'] );
 		}
 		add_action( 'admin_init', [ $this, 'maybe_redirect' ] );
+		add_action( 'admin_init', [ $this, 'init_no_script' ] );
 		if ( ! is_admin() && $this->settings->is_connected() && ! wp_next_scheduled( 'optml_daily_sync' ) ) {
 			wp_schedule_event( time() + 10, 'daily', 'optml_daily_sync', [] );
 		}
@@ -48,6 +49,16 @@ class Optml_Admin {
 		}
 	}
 
+	/**
+	 * Init no_script setup value based on whether the user is connected or not.
+	 */
+	public function init_no_script() {
+		if ( $this->settings->is_connected() ) {
+			if ( empty( $this->settings->get( 'no_script' ) ) ) {
+				$this->settings->update( 'no_script', 'enabled' );
+			}
+		}
+	}
 	/**
 	 * Checks if domain has changed
 	 */

--- a/inc/lazyload_replacer.php
+++ b/inc/lazyload_replacer.php
@@ -467,7 +467,7 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 	 * @return bool Should add?
 	 */
 	public function should_add_noscript( $tag ) {
-		if ( $this->settings->get( 'no_script') === 'disabled') {
+		if ( $this->settings->get( 'no_script' ) === 'disabled' ) {
 			return false;
 		}
 		foreach ( self::get_ignore_noscript_flags() as $banned_string ) {

--- a/inc/lazyload_replacer.php
+++ b/inc/lazyload_replacer.php
@@ -467,6 +467,9 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 	 * @return bool Should add?
 	 */
 	public function should_add_noscript( $tag ) {
+		if ( $this->settings->get( 'no_script') === 'disabled') {
+			return false;
+		}
 		foreach ( self::get_ignore_noscript_flags() as $banned_string ) {
 			if ( strpos( $tag, $banned_string ) !== false ) {
 				return false;

--- a/inc/main.php
+++ b/inc/main.php
@@ -24,6 +24,15 @@ final class Optml_Main {
 	public $manager;
 
 	/**
+	 * Holds the media_offload class.
+	 *
+	 * @access  public
+	 * @since   1.0.0
+	 * @var  Optml_Media_Offload instance.
+	 */
+	public $media_offload;
+
+	/**
 	 * Holds the rest class.
 	 *
 	 * @access  public

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -115,7 +115,7 @@ class Optml_Settings {
 	public function __construct() {
 
 		if ( self::$is_legacy_install === null ) {
-			//CHANGE THIS WHEN DEPLOYING LIVE
+			// CHANGE THIS WHEN DEPLOYING LIVE
 			self::$is_legacy_install = get_option( 'optimole_wp_install', 0 ) < 1681313471;
 		}
 
@@ -197,9 +197,10 @@ class Optml_Settings {
 			return null;
 		}
 
-		if ( $key === 'no_script' && isset( $this->options[ $key ] ) &&  $this->options[ $key ] === 'default' ) {
-			if ( self::$is_legacy_install )
+		if ( $key === 'no_script' && isset( $this->options[ $key ] ) && $this->options[ $key ] === 'default' ) {
+			if ( self::$is_legacy_install ) {
 				return 'enabled';
+			}
 			return 'disabled';
 		}
 		return isset( $this->options[ $key ] ) ? $this->options[ $key ] : '';

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -601,5 +601,14 @@ class Optml_Settings {
 
 		return $update;
 	}
+	/**
+	 * Get raw settings value.
+	 *
+	 * @return  array
+	 */
+	 public function get_raw_settings()
+	 {
+		 return get_option( $this->namespace, false );
+	 }
 
 }

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -43,12 +43,6 @@ class Optml_Settings {
 	private static $auto_connect_hooked = false;
 
 	/**
-	 * Checks if the plugin was installed before adding the no_script option.
-	 *
-	 * @var bool Used for enabling the option for old users.
-	 */
-	private static $is_legacy_install = null;
-	/**
 	 * Default settings schema.
 	 *
 	 * @var array Settings schema.
@@ -71,7 +65,7 @@ class Optml_Settings {
 		'video_lazyload'       => 'enabled',
 		'retina_images'        => 'disabled',
 		'resize_smart'         => 'disabled',
-		'no_script'            => 'default',
+		'no_script'            => 'disabled',
 		'filters'              => [],
 		'cloud_sites'          => [ 'all' => 'true' ],
 		'watchers'             => '',
@@ -113,11 +107,6 @@ class Optml_Settings {
 	 * Optml_Settings constructor.
 	 */
 	public function __construct() {
-
-		if ( self::$is_legacy_install === null ) {
-			// CHANGE THIS WHEN DEPLOYING LIVE
-			self::$is_legacy_install = get_option( 'optimole_wp_install', 0 ) < 1681313471;
-		}
 
 		$this->namespace      = OPTML_NAMESPACE . '_settings';
 		$this->default_schema = apply_filters( 'optml_default_settings', $this->default_schema );
@@ -197,12 +186,6 @@ class Optml_Settings {
 			return null;
 		}
 
-		if ( $key === 'no_script' && isset( $this->options[ $key ] ) && $this->options[ $key ] === 'default' ) {
-			if ( self::$is_legacy_install ) {
-				return 'enabled';
-			}
-			return 'disabled';
-		}
 		return isset( $this->options[ $key ] ) ? $this->options[ $key ] : '';
 	}
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -606,9 +606,8 @@ class Optml_Settings {
 	 *
 	 * @return  array
 	 */
-	 public function get_raw_settings()
-	 {
-		 return get_option( $this->namespace, false );
-	 }
+	public function get_raw_settings() {
+		return get_option( $this->namespace, false );
+	}
 
 }

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -41,6 +41,13 @@ class Optml_Settings {
 	 * @var boolean Whether or not the auto connect action is hooked.
 	 */
 	private static $auto_connect_hooked = false;
+
+	/**
+	 * Checks if the plugin was installed before adding the no_script option.
+	 *
+	 * @var bool Used for enabling the option for old users.
+	 */
+	private static $is_legacy_install = null;
 	/**
 	 * Default settings schema.
 	 *
@@ -64,6 +71,7 @@ class Optml_Settings {
 		'video_lazyload'       => 'enabled',
 		'retina_images'        => 'disabled',
 		'resize_smart'         => 'disabled',
+		'no_script'            => 'default',
 		'filters'              => [],
 		'cloud_sites'          => [ 'all' => 'true' ],
 		'watchers'             => '',
@@ -105,6 +113,12 @@ class Optml_Settings {
 	 * Optml_Settings constructor.
 	 */
 	public function __construct() {
+
+		if ( self::$is_legacy_install === null ) {
+			//CHANGE THIS WHEN DEPLOYING LIVE
+			self::$is_legacy_install = get_option( 'optimole_wp_install', 0 ) < 1681313471;
+		}
+
 		$this->namespace      = OPTML_NAMESPACE . '_settings';
 		$this->default_schema = apply_filters( 'optml_default_settings', $this->default_schema );
 		$this->options        = wp_parse_args( get_option( $this->namespace, $this->default_schema ), $this->default_schema );
@@ -183,6 +197,11 @@ class Optml_Settings {
 			return null;
 		}
 
+		if ( $key === 'no_script' && isset( $this->options[ $key ] ) &&  $this->options[ $key ] === 'default' ) {
+			if ( self::$is_legacy_install )
+				return 'enabled';
+			return 'disabled';
+		}
 		return isset( $this->options[ $key ] ) ? $this->options[ $key ] : '';
 	}
 
@@ -240,6 +259,7 @@ class Optml_Settings {
 				case 'css_minify':
 				case 'js_minify':
 				case 'native_lazyload':
+				case 'no_script':
 					$sanitized_value = $this->to_map_values( $value, [ 'enabled', 'disabled' ], 'enabled' );
 					break;
 				case 'max_width':
@@ -419,6 +439,7 @@ class Optml_Settings {
 			'bg_replacer'          => $this->get( 'bg_replacer' ),
 			'video_lazyload'       => $this->get( 'video_lazyload' ),
 			'resize_smart'         => $this->get( 'resize_smart' ),
+			'no_script'            => $this->get( 'no_script' ),
 			'image_replacer'       => $this->get( 'image_replacer' ),
 			'cdn'                  => $this->get( 'cdn' ),
 			'max_width'            => $this->get( 'max_width' ),

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -61,7 +61,7 @@ class Optml_Settings {
 		'network_optimization' => 'disabled',
 		'lazyload_placeholder' => 'disabled',
 		'bg_replacer'          => 'enabled',
-		'video_lazyload'       => 'disabled',
+		'video_lazyload'       => 'enabled',
 		'retina_images'        => 'disabled',
 		'resize_smart'         => 'disabled',
 		'filters'              => [],

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="Optimole">
     <description>Optimole rules for PHP_CodeSnifferr</description>
-
+    <ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
     <file>.</file>
 
     <exclude-pattern>node_modules/*</exclude-pattern>

--- a/tests/test-lazyload-class-exclusion.php
+++ b/tests/test-lazyload-class-exclusion.php
@@ -27,6 +27,7 @@ class Test_Lazyload_Class_Exclusion extends WP_UnitTestCase
 		]);
 
 		$settings->update('lazyload', 'enabled');
+		$settings->update('no_script', 'enabled');
 		$settings->update('filters', array(
 			Optml_Settings::FILTER_TYPE_LAZYLOAD => array (
 			 Optml_Settings::FILTER_CLASS => array (

--- a/tests/test-lazyload.php
+++ b/tests/test-lazyload.php
@@ -36,6 +36,7 @@ class Test_Lazyload extends WP_UnitTestCase {
 		$settings->update( 'lazyload', 'enabled' );
 		$settings->update( 'native_lazyload', 'enabled' );
 		$settings->update( 'video_lazyload', 'enabled' );
+		$settings->update( 'no_script', 'enabled' );
 		Optml_Url_Replacer::instance()->init();
 		Optml_Tag_Replacer::instance()->init();
 		Optml_Lazyload_Replacer::instance()->init();

--- a/tests/test-media.php
+++ b/tests/test-media.php
@@ -139,6 +139,7 @@ class Test_Media extends WP_UnitTestCase {
 			'whitelist'  => [ 'example.com', 'example.org' ],
 
 		] );
+		$settings->update( 'no_script', 'enabled' );
 		$settings->update( 'lazyload', 'enabled' );
 		$settings->update( 'offload_media', 'enabled' );
 		$settings->update( 'quality', 90 );

--- a/tests/test-no-script-disabled.php
+++ b/tests/test-no-script-disabled.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * WordPress unit test plugin.
+ *
+ * @package     Optimole-WP
+ * @subpackage  Tests
+ * @copyright   Copyright (c) 2017, ThemeIsle
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class Test_Generic.
+ */
+class Test_Lazyload_No_Script extends WP_UnitTestCase
+{
+
+
+	public function setUp(): void
+	{
+		parent::setUp();
+		$settings = new Optml_Settings();
+		$settings->update('service_data', [
+			'cdn_key' => 'test123',
+			'cdn_secret' => '12345',
+			'whitelist' => ['example.com'],
+
+		]);
+		$settings->update('lazyload', 'enabled');
+		$settings->update('native_lazyload', 'enabled');
+		$settings->update('video_lazyload', 'enabled');
+		$settings->update('no_script', 'disabled');
+		Optml_Url_Replacer::instance()->init();
+		Optml_Tag_Replacer::instance()->init();
+		Optml_Lazyload_Replacer::instance()->init();
+		Optml_Manager::instance()->init();
+
+		self::$sample_attachement = self::factory()->attachment->create_upload_object(OPTML_PATH . 'assets/img/logo.png');
+	}
+
+	//changing the setting to disabled in a test inside the lazyload class will not work due to test concurrency
+	//moved this to a different test
+	public function test_no_script_disabled()
+	{
+		$text = ' <a href="http://example.org/wp-content/uploads/2018/06/start-a-blog-1-5.png"><img class="alignnone wp-image-36442 size-full" src="http://example.org/wp-content/uploads/2018/06/start-a-blog-1-5.png"  srcset="testsrcset" data-srcset="another" data-plugin-src="http://example.org/wp-content/uploads/2018/06/start-a-blog-1-5.png" alt="How to monetize a blog" width="490" height="256"></a>';
+
+		$replaced_content = Optml_Manager::instance()->replace_content($text);
+
+		$this->assertStringNotContainsString('noscript', $replaced_content);
+	}
+}

--- a/tests/test-no-script-disabled.php
+++ b/tests/test-no-script-disabled.php
@@ -14,7 +14,6 @@
 class Test_Lazyload_No_Script extends WP_UnitTestCase
 {
 
-
 	public function setUp(): void
 	{
 		parent::setUp();
@@ -33,8 +32,6 @@ class Test_Lazyload_No_Script extends WP_UnitTestCase
 		Optml_Tag_Replacer::instance()->init();
 		Optml_Lazyload_Replacer::instance()->init();
 		Optml_Manager::instance()->init();
-
-		self::$sample_attachement = self::factory()->attachment->create_upload_object(OPTML_PATH . 'assets/img/logo.png');
 	}
 
 	//changing the setting to disabled in a test inside the lazyload class will not work due to test concurrency


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
 For the iframe and video lazyload the option will be enabled for new users while for old install will stay the same. 

 Adds an option to control whether or not `<noscript>` tag should be added. For new install it will be off by default and for users that already had the plugin connected it will be on.

 Declares the `media_offload` property on the class to avoid depracation notice. 

Closes https://github.com/Codeinwp/optimole-wp/issues/505 ,  https://github.com/Codeinwp/optimole-wp/issues/509, https://github.com/Codeinwp/optimole-wp/issues/520.

### How to test the changes in this Pull Request:

For the noscript option, on the case of fresh installs. 

1. Install the pr plugin and connect it to an account.
2. Check that the noscript option is off by default.

For the noscript option, on the case when the plugin is already connected and the user updates. 

1. Install the current plugin version. 
2. Connect an account to it. 
3. Update the plugin with the pr version. 
4. Check that the plugin has the noscript option enabled. 
5. If you change the noscript option, lets say disable it, it should remain disabled.

For the iframe and video lazyload, on the case of fresh installs. 

1. Install the pr plugin and connect it to an account.
2. Check that the iframe and video lazyload is enabled. 

For the iframe option, on the case when the plugin is already connected and the user updates. 

1. Install the current plugin version. 
2. Connect an account to it. 
3. Update the plugin with the pr version. 
4. Check that the plugin has the iframe and video lazyload disabled as it was before updating the plugin. 

For the depracated notice. 

1. Make sure the test instance has `WP_DEBUG` on. 
2. Install the pr plugin. 
3. Check the debug logs.
4. The depracted notice from https://github.com/Codeinwp/optimole-wp/issues/520 should not appear.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?version. 
