### PR TITLE
added wildcard background lazy selector for wp_block_cover #758

### DIFF
--- a/inc/lazyload_replacer.php
+++ b/inc/lazyload_replacer.php
@@ -124,7 +124,7 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 		$default_watchers = [
 			'.elementor-section[data-settings*="background_background"]',
 			'.elementor-section > .elementor-background-overlay',
-			'.wp-block-cover[style*="background-image"]',
+			'[class*="wp-block-cover"][style*="background-image"]',
 		];
 
 		$saved_watchers = self::instance()->settings->get_watchers();


### PR DESCRIPTION
Fixes https://github.com/Codeinwp/optimole-service/issues/758 . 

Using `[class*="wp-block-cover"][style*="background-image"]` will target both the old selector and the new ones that might be used. 
 
