### PR TITLE
chore: checking http_referer on page exclusions #437

### DIFF
--- a/inc/filters.php
+++ b/inc/filters.php
@@ -16,21 +16,32 @@ final class Optml_Filters {
 	 * @return bool Should do action on page?
 	 */
 	public static function should_do_page( $contains_flags, $match_flags ) {
+
+		if ( empty( $contains_flags ) && empty( $match_flags ) ) {
+			return true;
+		}
+
 		if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
 			return true;
 		}
 
-		foreach ( $match_flags as $rule_flag => $status ) {
-			if ( $rule_flag === $_SERVER['REQUEST_URI'] ) {
-				return false;
-			}
+		$check_against = [ $_SERVER['REQUEST_URI'] ];
+		if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
+			$check_against[] = $_SERVER['HTTP_REFERER'];
 		}
-		foreach ( $contains_flags as $rule_flag => $status ) {
-			if ( strpos( $_SERVER['REQUEST_URI'], $rule_flag ) !== false ) {
-				return false;
+		foreach ( $check_against as $check ) {
+			foreach ( $match_flags as $rule_flag => $status ) {
+				if ( $rule_flag === $check ) {
+					return false;
+				}
 			}
-			if ( $rule_flag === 'home' && ( empty( $_SERVER['REQUEST_URI'] ) || $_SERVER['REQUEST_URI'] === '/' ) ) {
-				return false;
+			foreach ( $contains_flags as $rule_flag => $status ) {
+				if ( strpos( $check, $rule_flag ) !== false ) {
+					return false;
+				}
+				if ( $rule_flag === 'home' && ( empty( $check ) || $check === '/' ) ) {
+					return false;
+				}
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
 When checking the page exclusions we can also check the `HTTP_REFERER` to exclude images from ajax calls within a excluded page. 

   I also added an early exit condition to avoid redundant checks to run for users that do not have any exclusions added. 

Closes #437 .

### How to test the changes in this Pull Request:

1. Install the pr plugin and add an exclusion for page urls that contain `checkout` https://vertis.d.pr/i/7MG5cx.
2. Install https://wordpress.org/plugins/fluid-checkout/ and configure a small woocomerce shop (with images for products) and the fluid checkout plugin. I recommend neve + template cloud to setup a fast shop (just a suggestion).
3. From a browser where you are not logged in as admin, add a product to the cart and go to checkout, the product image should not be optimized https://vertis.d.pr/i/yhhI4s .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
