### PR TITLE
Fix Show Sample button not displaying when expected

### DIFF
--- a/assets/vue/components/compression.vue
+++ b/assets/vue/components/compression.vue
@@ -257,6 +257,7 @@ export default {
     }
   },
   mounted: function () {
+    this.showSample = this.$store.state.site_settings.quality !== 'auto';
   },
   methods: {
     saveChanges: function () {
@@ -325,6 +326,7 @@ export default {
     autoQuality: {
       set: function (value) {
         this.showSave = true;
+        this.showSample = ! this.showSample;
         this.showManualQuality = ! value;
         this.new_data.autoquality = value ? 'enabled' : 'disabled';
       },

--- a/assets/vue/components/compression.vue
+++ b/assets/vue/components/compression.vue
@@ -257,7 +257,7 @@ export default {
     }
   },
   mounted: function () {
-    this.showSample = this.$store.state.site_settings.quality !== 'auto';
+    this.showSample = this.site_settings.autoquality === 'disabled';
   },
   methods: {
     saveChanges: function () {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
Previously if you just toggle off the Auto Quality control, the View Sample wasn't appearing, you had to adjust the slider for it to appear. 
 

Closes #515.

### How to test the changes in this Pull Request:

1. Go to Media > Optimole
2. Open Settings > Advanced > Compression
3. Disable the Auto Quality toggle, and View Sample button should appear, and it should close too if you toggle it off.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
