### PR TITLE
Add Otter lazy-load selectors

### DIFF
--- a/cypress/e2e/test_otter_background_lazyload.js
+++ b/cypress/e2e/test_otter_background_lazyload.js
@@ -2,16 +2,30 @@ describe("Check Otter Background Lazyload", function () {
     it("successfully loads", function () {
       cy.visit("/otter/background-lazyload/");
     });
-    it("Otter Flip block should have background lazyloaded", function () {
+    it("Otter Flip block front should have background lazyloaded", function () {
       cy.get(".wp-block-themeisle-blocks-flip")
-        .find(".o-flip-content")
+        .find(".o-flip-front")
         .eq(0)
         .should("have.attr", "class")
         .and("include", "optml-bg-lazyloaded");
     });
-    it("Otter Flip block should have background image url optimized (ie. external css is processed)", function () {
+    it("Otter Flip block front should have background image url optimized (ie. external css is processed)", function () {
         cy.get(".wp-block-themeisle-blocks-flip")
-        .find(".o-flip-content")
+        .find(".o-flip-front")
+        .eq(0)
+        .should("have.css", "background-image")
+        .and("match", /url\(.*\.i\.optimole\.com.*\)/);
+    });
+    it("Otter Flip block back should have background lazyloaded", function () {
+      cy.get(".wp-block-themeisle-blocks-flip")
+        .find(".o-flip-back")
+        .eq(0)
+        .should("have.attr", "class")
+        .and("include", "optml-bg-lazyloaded");
+    });
+    it("Otter Flip block back should have background image url optimized (ie. external css is processed)", function () {
+        cy.get(".wp-block-themeisle-blocks-flip")
+        .find(".o-flip-back")
         .eq(0)
         .should("have.css", "background-image")
         .and("match", /url\(.*\.i\.optimole\.com.*\)/);

--- a/cypress/e2e/test_otter_background_lazyload.js
+++ b/cypress/e2e/test_otter_background_lazyload.js
@@ -36,6 +36,7 @@ describe("Check Otter Background Lazyload", function () {
     });
 
     it("Otter Section Block should have background lazyloaded", function () {
+      cy.scrollTo( 0, 500 );
       cy.get("#wp-block-themeisle-blocks-advanced-columns-e62611eb")
         .eq(0)
         .should("have.attr", "class")
@@ -50,8 +51,8 @@ describe("Check Otter Background Lazyload", function () {
     });
 
     it("Otter Section Block's Overlay should have background lazyloaded", function () {
-      cy.get("#wp-block-themeisle-blocks-advanced-columns-e62611eb")
-      .find(".wp-block-themeisle-blocks-advanced-columns-overlay")
+        cy.get("#wp-block-themeisle-blocks-advanced-columns-e62611eb")
+        .find(".wp-block-themeisle-blocks-advanced-columns-overlay")
         .eq(0)
         .should("have.attr", "class")
         .and("include", "optml-bg-lazyloaded");

--- a/cypress/e2e/test_otter_background_lazyload.js
+++ b/cypress/e2e/test_otter_background_lazyload.js
@@ -1,0 +1,20 @@
+describe("Check Otter Background Lazyload", function () {
+    it("successfully loads", function () {
+      cy.visit("/otter/background-lazyload/");
+    });
+    it("Otter Flip block should have background lazyloaded", function () {
+      cy.get(".wp-block-themeisle-blocks-flip")
+        .find(".o-flip-content")
+        .eq(0)
+        .should("have.attr", "class")
+        .and("include", "optml-bg-lazyloaded");
+    });
+    it("Otter Flip block should have background image url optimized (ie. external css is processed)", function () {
+        cy.get(".wp-block-themeisle-blocks-flip")
+        .find(".o-flip-content")
+        .eq(0)
+        .should("have.css", "background-image")
+        .and("match", /url\(.*\.i\.optimole\.com.*\)/);
+    });
+  });
+  

--- a/cypress/e2e/test_otter_background_lazyload.js
+++ b/cypress/e2e/test_otter_background_lazyload.js
@@ -36,7 +36,7 @@ describe("Check Otter Background Lazyload", function () {
     });
 
     it("Otter Section Block should have background lazyloaded", function () {
-      cy.get(".#wp-block-themeisle-blocks-advanced-columns-e62611eb")
+      cy.get("#wp-block-themeisle-blocks-advanced-columns-e62611eb")
         .eq(0)
         .should("have.attr", "class")
         .and("include", "optml-bg-lazyloaded");
@@ -50,7 +50,7 @@ describe("Check Otter Background Lazyload", function () {
     });
 
     it("Otter Section Block's Overlay should have background lazyloaded", function () {
-      cy.get(".#wp-block-themeisle-blocks-advanced-columns-e62611eb")
+      cy.get("#wp-block-themeisle-blocks-advanced-columns-e62611eb")
       .find(".wp-block-themeisle-blocks-advanced-columns-overlay")
         .eq(0)
         .should("have.attr", "class")

--- a/cypress/e2e/test_otter_background_lazyload.js
+++ b/cypress/e2e/test_otter_background_lazyload.js
@@ -2,6 +2,7 @@ describe("Check Otter Background Lazyload", function () {
     it("successfully loads", function () {
       cy.visit("/otter/background-lazyload/");
     });
+
     it("Otter Flip block front should have background lazyloaded", function () {
       cy.get(".wp-block-themeisle-blocks-flip")
         .find(".o-flip-front")
@@ -9,6 +10,7 @@ describe("Check Otter Background Lazyload", function () {
         .should("have.attr", "class")
         .and("include", "optml-bg-lazyloaded");
     });
+
     it("Otter Flip block front should have background image url optimized (ie. external css is processed)", function () {
         cy.get(".wp-block-themeisle-blocks-flip")
         .find(".o-flip-front")
@@ -16,6 +18,7 @@ describe("Check Otter Background Lazyload", function () {
         .should("have.css", "background-image")
         .and("match", /url\(.*\.i\.optimole\.com.*\)/);
     });
+
     it("Otter Flip block back should have background lazyloaded", function () {
       cy.get(".wp-block-themeisle-blocks-flip")
         .find(".o-flip-back")
@@ -23,9 +26,40 @@ describe("Check Otter Background Lazyload", function () {
         .should("have.attr", "class")
         .and("include", "optml-bg-lazyloaded");
     });
+
     it("Otter Flip block back should have background image url optimized (ie. external css is processed)", function () {
         cy.get(".wp-block-themeisle-blocks-flip")
         .find(".o-flip-back")
+        .eq(0)
+        .should("have.css", "background-image")
+        .and("match", /url\(.*\.i\.optimole\.com.*\)/);
+    });
+
+    it("Otter Section Block should have background lazyloaded", function () {
+      cy.get(".#wp-block-themeisle-blocks-advanced-columns-e62611eb")
+        .eq(0)
+        .should("have.attr", "class")
+        .and("include", "optml-bg-lazyloaded");
+    });
+
+    it("Otter Section Block should have background image url optimized (ie. external css is processed)", function () {
+        cy.get("#wp-block-themeisle-blocks-advanced-columns-e62611eb")
+        .eq(0)
+        .should("have.css", "background-image")
+        .and("match", /url\(.*\.i\.optimole\.com.*\)/);
+    });
+
+    it("Otter Section Block's Overlay should have background lazyloaded", function () {
+      cy.get(".#wp-block-themeisle-blocks-advanced-columns-e62611eb")
+      .find(".wp-block-themeisle-blocks-advanced-columns-overlay")
+        .eq(0)
+        .should("have.attr", "class")
+        .and("include", "optml-bg-lazyloaded");
+    });
+
+    it("Otter Section Block's Overlay should have background image url optimized (ie. external css is processed)", function () {
+        cy.get("#wp-block-themeisle-blocks-advanced-columns-e62611eb")
+        .find(".wp-block-themeisle-blocks-advanced-columns-overlay")
         .eq(0)
         .should("have.css", "background-image")
         .and("match", /url\(.*\.i\.optimole\.com.*\)/);

--- a/inc/compatibilities/otter_blocks.php
+++ b/inc/compatibilities/otter_blocks.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Class Optml_otter_blocks.
+ *
+ * @reason Adding selectors for background lazyload
+ */
+class Optml_otter_blocks extends Optml_compatibility {
+
+
+	/**
+	 * Should we load the integration logic.
+	 *
+	 * @return bool Should we load.
+	 */
+	function should_load() {
+		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
+		return is_plugin_active( 'otter-blocks/otter-blocks.php' );
+	}
+
+	/**
+	 * Register integration details.
+	 */
+	public function register() {
+		add_filter(
+			'optml_lazyload_bg_selectors',
+			function ( $all_watchers ) {
+				$all_watchers[] = '.o-flip-front';
+				$all_watchers[] = '.o-flip-back';
+				$all_watchers[] = '.wp-block-themeisle-blocks-advanced-columns';
+				$all_watchers[] = '.wp-block-themeisle-blocks-advanced-columns-overlay';
+				$all_watchers[] = '.wp-block-themeisle-blocks-advanced-column';
+				$all_watchers[] = '.wp-block-themeisle-blocks-advanced-column-overlay';
+
+				return $all_watchers;
+			}
+		);
+	}
+
+}

--- a/inc/compatibilities/otter_blocks.php
+++ b/inc/compatibilities/otter_blocks.php
@@ -38,7 +38,7 @@ class Optml_otter_blocks extends Optml_compatibility {
 		);
 
 		// Replace the image URL with the optimized one in Otter-generated CSS.
-		add_filter( 'otter_apply_dynamic_image', [ Optml_Main::instance()->manager->url_replacer, 'build_url' ], PHP_INT_MAX, 1 );
+		add_filter( 'otter_apply_dynamic_image', [ Optml_Main::instance()->manager->url_replacer, 'build_url' ], 99 );
 	}
 
 }

--- a/inc/compatibilities/otter_blocks.php
+++ b/inc/compatibilities/otter_blocks.php
@@ -36,6 +36,9 @@ class Optml_otter_blocks extends Optml_compatibility {
 				return $all_watchers;
 			}
 		);
+
+		// Replace the image URL with the optimized one in Otter-generated CSS.
+		add_filter( 'otter_apply_dynamic_image', [ Optml_Main::instance()->manager->url_replacer, 'build_url' ], PHP_INT_MAX, 1 );
 	}
 
 }

--- a/inc/manager.php
+++ b/inc/manager.php
@@ -83,6 +83,7 @@ final class Optml_Manager {
 		'wp_bakery',
 		'elementor_builder_late',
 		'wpml',
+		'otter_blocks',
 	];
 	/**
 	 * The current state of the buffer.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
Add lazyload selectors for Otter & also replace internal URLs in CSS with Optimole ones.
 
@GrigoreMihai I wanted to add e2e tests here. Can you give me access to the testing.optimole.com website?


Closes [#755](https://github.com/Codeinwp/optimole-service/issues/755).

### How to test the changes in this Pull Request:

1. Insert Flip and Section block from Otter
2. Add a background image to both of them.
3. The background should lazyload in frontend. Ie it should have `optml-bg-lazyloaded` class after coming into view.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
