### PR TITLE
Update stats when last image section has loaded

### DIFF
--- a/assets/vue/components/last-images.vue
+++ b/assets/vue/components/last-images.vue
@@ -88,6 +88,7 @@
 			}
 			this.doProgressBar();
 			this.$store.dispatch('retrieveOptimizedImages', {waitTime: this.maxTime * 1000, component: this});
+			this.$store.dispatch('requestStatsUpdate', {waitTime: 0, component: null});
 		},
 		watch: {
 			imageData: function () {

--- a/assets/vue/store/actions.js
+++ b/assets/vue/store/actions.js
@@ -44,7 +44,7 @@ const selectOptimoleDomain = function ( {commit, state}, data ) {
 	);
 }
 
-const connectOptimole = function ( {commit, state}, data ) {
+const connectOptimole = function ( {dispatch, commit, state}, data ) {
 	commit( 'toggleConnecting', true );
 	commit( 'restApiNotWorking', false );
 	Vue.http(
@@ -72,7 +72,7 @@ const connectOptimole = function ( {commit, state}, data ) {
 					commit( 'toggleHasOptmlApp', true );
 				  }
 
-				  sendOnboardImages();
+				  dispatch( 'sendOnboardImages', [] );
 
 				  console.log( '%c OptiMole API connection successful.', 'color: #59B278' );
 
@@ -89,7 +89,7 @@ const connectOptimole = function ( {commit, state}, data ) {
 	);
 };
 
-const registerOptimole = function ( {commit, state}, data ) {
+const registerOptimole = function ( {dispatch, commit, state}, data ) {
 
 	commit( 'restApiNotWorking', false );
 	commit( 'toggleConnecting', true );
@@ -117,7 +117,7 @@ const registerOptimole = function ( {commit, state}, data ) {
 				commit( 'updateApiKey', data.apiKey );
 				commit( 'updateUserData', response.body.data );
 				commit( 'updateAvailableApps', response.body.data );
-				sendOnboardImages();
+				dispatch( 'sendOnboardImages', {} );
 			}
 			return response.data;
 		},
@@ -287,13 +287,15 @@ const retrieveOptimizedImages = function ( {commit, state}, data ) {
 	);
 };
 
-const sendOnboardImages = function( offset = 0 ) {
+const sendOnboardImages = function ( { dispatch }, data ) {
+	data.offset = undefined !== data.offset ? data.offset : 0;
+
 	Vue.http(
 		{
 			url: optimoleDashboardApp.routes['upload_onboard_images'],
 			method: 'POST',
 			params: {
-				offset
+				offset: data.offset
 			},
 			emulateJSON: true,
 			headers: {'X-WP-Nonce': optimoleDashboardApp.nonce},
@@ -301,8 +303,10 @@ const sendOnboardImages = function( offset = 0 ) {
 		}
 	).then(
 		function ( response ) {
-			if ( false === response.body.data && offset < 1000 ) {
-				sendOnboardImages( offset + 50 );
+			if ( false === response.body.data && data.offset < 1000 ) {
+				dispatch( 'sendOnboardImages', {
+					offset: data.offset + 100
+				} );
 			}
 
 			if ( response.body.code === 'success' ) {
@@ -659,6 +663,7 @@ export default {
 	retrieveOptimizedImages,
 	retrieveWatermarks,
 	sampleRate,
+	sendOnboardImages,
 	saveSettings,
 	callSync,
 	getOffloadConflicts


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
When you connect to Optimole and the image section is loaded, it updates dashboard stats to reflect latest count. Turned out easier than I expected without any expected issues.
 

Closes #508.

### How to test the changes in this Pull Request:

1. On a new instance, have some images and connect to Optimole.
2. Once the connecting finishes and "Last optimized images" section loads, you should see Image Optimized count update.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
