### PR TITLE
chore: fixed bg lazyload breaking divi blog module #527

### DIFF
--- a/inc/compatibilities/divi_builder.php
+++ b/inc/compatibilities/divi_builder.php
@@ -35,7 +35,7 @@ class Optml_divi_builder extends Optml_compatibility {
 				$all_watchers[] = '.et_pb_slides > .et_pb_slide';
 				$all_watchers[] = '.et_parallax_bg';
 				$all_watchers[] = '.et_pb_video_overlay';
-				$all_watchers[] = '.et_pb_module:not(.et_pb_blog*)';
+				$all_watchers[] = '.et_pb_module:not([class*="et_pb_blog"])';
 				$all_watchers[] = '.et_pb_row';
 				$all_watchers[] = '.et_pb_section.et_pb_section_1';
 				$all_watchers[] = '.et_pb_with_background';

--- a/inc/compatibilities/divi_builder.php
+++ b/inc/compatibilities/divi_builder.php
@@ -35,7 +35,7 @@ class Optml_divi_builder extends Optml_compatibility {
 				$all_watchers[] = '.et_pb_slides > .et_pb_slide';
 				$all_watchers[] = '.et_parallax_bg';
 				$all_watchers[] = '.et_pb_video_overlay';
-				$all_watchers[] = '.et_pb_module:not(.et_pb_blog_grid_wrapper)';
+				$all_watchers[] = '.et_pb_module:not(.et_pb_blog*)';
 				$all_watchers[] = '.et_pb_row';
 				$all_watchers[] = '.et_pb_section.et_pb_section_1';
 				$all_watchers[] = '.et_pb_with_background';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
 The issue here was that we were applying background lazyload to the divi blog container which was breaking it.  Changed the filtering to use a regex `:not([class*="et_pb_blog"])` so we would avoid this on future class name changes. 

Closes #527 .

### How to test the changes in this Pull Request:

1. Install divi theme and create at least 10 posts(to make the navigation appear) and a use the divi blog module on a page. For this step there are more detailed steps here: https://github.com/Codeinwp/optimole-wp/issues/527 and also a useful screencast: https://vertis.d.pr/v/61xSIG .
2. Use the pr plugin and enable the backgroud lazyload option. 
3. Check that navigating between `older entries` and `newer entries` works as expected. (before the fix there will be pages with blank body) 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
