### PR TITLE
Fix/510

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -60,7 +60,7 @@ class Optml_Settings {
 		'lazyload'             => 'disabled',
 		'scale'                => 'disabled',
 		'network_optimization' => 'disabled',
-		'lazyload_placeholder' => 'disabled',
+		'lazyload_placeholder' => 'enabled',
 		'bg_replacer'          => 'enabled',
 		'video_lazyload'       => 'enabled',
 		'retina_images'        => 'disabled',

--- a/tests/test-lazyload-class-exclusion.php
+++ b/tests/test-lazyload-class-exclusion.php
@@ -28,6 +28,7 @@ class Test_Lazyload_Class_Exclusion extends WP_UnitTestCase
 
 		$settings->update('lazyload', 'enabled');
 		$settings->update('no_script', 'enabled');
+		$settings->update( 'lazyload_placeholder', 'disabled' );
 		$settings->update('filters', array(
 			Optml_Settings::FILTER_TYPE_LAZYLOAD => array (
 			 Optml_Settings::FILTER_CLASS => array (

--- a/tests/test-lazyload.php
+++ b/tests/test-lazyload.php
@@ -36,6 +36,7 @@ class Test_Lazyload extends WP_UnitTestCase {
 		$settings->update( 'lazyload', 'enabled' );
 		$settings->update( 'native_lazyload', 'enabled' );
 		$settings->update( 'video_lazyload', 'enabled' );
+		$settings->update( 'lazyload_placeholder', 'disabled' );
 		$settings->update( 'no_script', 'enabled' );
 		Optml_Url_Replacer::instance()->init();
 		Optml_Tag_Replacer::instance()->init();

--- a/tests/test-media.php
+++ b/tests/test-media.php
@@ -142,6 +142,7 @@ class Test_Media extends WP_UnitTestCase {
 		$settings->update( 'no_script', 'enabled' );
 		$settings->update( 'lazyload', 'enabled' );
 		$settings->update( 'offload_media', 'enabled' );
+		$settings->update( 'lazyload_placeholder', 'disabled' );
 		$settings->update( 'quality', 90 );
 		$settings->update( 'cdn', 'enabled' );
 		Optml_Url_Replacer::instance()->init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
 Changes the default value of the lazyload placeholder to enabled. For old users there is nothing special we need to do as the settings is already saved and will not change. 

Closes #510 .

### How to test the changes in this Pull Request:

First part: 

1. Install the pr plugin.
2. The lazyload placeholder should be enabled by default.

Second part: 

1. Install and activate the current plugin without these changes, make sure the lazyload placeholder is disabled. 
2. Updated the plugin with the one in the pr. 
3. Check that the lazyload placeholder option remains disabled after updating. 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
