### PR TITLE
feat: implement maxWidth and maxHeight setting

### DIFF
--- a/assets/vue/components/resize.vue
+++ b/assets/vue/components/resize.vue
@@ -35,8 +35,54 @@
             </div>
 
         </div>
-        <hr/>
-        <div class="field  columns">
+
+      <hr/>
+      <div class="field  columns">
+        <label class="label column has-text-grey-dark optml-custom-label-margin">
+          {{ strings.enable_limit_dimensions_title }}
+          <p class="optml-settings-desc-margin has-text-weight-normal">
+            {{ strings.enable_limit_dimensions_desc }}
+          </p>
+        </label>
+        <div class="column is-1">
+          <toggle-button :class="'has-text-dark'"
+                         v-model="limitDimensions"
+                         :disabled="this.$store.state.loading"
+                         :width="37"
+                         :height="20"
+                         color="#577BF9"></toggle-button>
+        </div>
+      </div>
+
+      <div v-if="dimensionsOn">
+        <div class="column is-6 ">
+          <div class="columns">
+
+            <div class="field column is-narrow has-addons" style="align-items: center;">
+              <p class="optml-custom-label-margin">
+                {{ strings.width_field }}
+              </p>
+              <input v-model="limitWidth" class="optml-textarea" type="number" min="100" max="10000">
+            </div>
+
+            <div class="field column is-narrow has-addons" style="align-items: center;  margin-bottom: 0.75rem;">
+              <p class="optml-custom-label-margin">
+                {{ strings.height_field }}
+              </p>
+              <input v-model="limitHeight" class="optml-textarea" type="number" min="100" max="10000">
+            </div>
+
+          </div>
+        </div>
+
+        <p class="has-text-weight-normal optml-restore-notice-background" style="padding: 2%;">
+          {{ strings.enable_limit_dimensions_notice }}
+        </p>
+      </div>
+
+      <hr/>
+
+      <div class="field  columns">
 
           <div class="columns"  style="width: 100%;margin-left: 3px;">
           <div class="optml-fill-container">
@@ -144,6 +190,7 @@
                 all_strings: optimoleDashboardApp.strings,
                 size_width: '',
                 size_height: '',
+                dimensionsOn: optimoleDashboardApp.site_settings.limit_dimensions === 'enabled',
                 crop: false,
                 showSave: false,
                 new_data:{},
@@ -238,7 +285,35 @@
                 get: function () {
                     return !(this.site_settings.retina_images === 'disabled');
                 }
-            }
+            },
+            limitDimensions: {
+              set: function (value) {
+                this.showSave = true;
+                this.dimensionsOn = value;
+                this.new_data.limit_dimensions = value ? 'enabled' : 'disabled';
+              },
+              get: function () {
+                return !(this.site_settings.limit_dimensions === 'disabled');
+              }
+            },
+            limitHeight: {
+              set: function (value) {
+                this.showSave = true;
+                this.new_data.limit_height = value;
+              },
+              get: function () {
+                return this.site_settings.limit_height;
+              }
+            },
+            limitWidth: {
+              set: function (value) {
+                this.showSave = true;
+                this.new_data.limit_width = value;
+              },
+              get: function () {
+                return this.site_settings.limit_width;
+              }
+            },
         }
     }
 </script>

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -222,8 +222,8 @@ class Optml_Admin {
 		$watcher_classes       = empty( $watcher_classes ) ? '' : sprintf( '"%s"', implode( '","', (array) $watcher_classes ) );
 		$default_network       = ( $this->settings->get( 'network_optimization' ) === 'enabled' );
 		$limit_dimensions      = $this->settings->get( 'limit_dimensions' ) === 'enabled';
-		$limit_width           = $this->settings->get( 'limit_width' );
-		$limit_height          = $this->settings->get( 'limit_height' );
+		$limit_width           = $limit_dimensions ? $this->settings->get( 'limit_width' ) : 0;
+		$limit_height          = $limit_dimensions ? $this->settings->get( 'limit_height' ) : 0;
 		$retina_ready          = $limit_dimensions ||
 								 ! ( $this->settings->get( 'retina_images' ) === 'enabled' );
 		$scale_is_disabled     = ( $this->settings->get( 'scale' ) === 'enabled' );

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -22,6 +22,8 @@ class Optml_Admin {
 	 */
 	public $settings;
 
+	const NEW_USER_DEFAULTS_UPDATED = 'optml_defaults_updated';
+
 	/**
 	 * Optml_Admin constructor.
 	 */
@@ -37,6 +39,7 @@ class Optml_Admin {
 		if ( $this->settings->is_connected() ) {
 			add_action( 'init', [$this, 'check_domain_change'] );
 		}
+		add_action( 'init', [ $this, 'update_default_settings' ] );
 		add_action( 'admin_init', [ $this, 'maybe_redirect' ] );
 		add_action( 'admin_init', [ $this, 'init_no_script' ] );
 		if ( ! is_admin() && $this->settings->is_connected() && ! wp_next_scheduled( 'optml_daily_sync' ) ) {
@@ -73,6 +76,23 @@ class Optml_Admin {
 				$this->daily_sync();
 			}
 		}
+	}
+	/**
+	 * Update the limit dimensions setting to enabled if the user is new.
+	 */
+	public function update_default_settings() {
+		if ( get_option( self::NEW_USER_DEFAULTS_UPDATED ) === 'yes' ) {
+			return;
+		}
+
+		if ( $this->settings->is_connected() ) {
+			update_option( self::NEW_USER_DEFAULTS_UPDATED, 'yes' );
+			return;
+		}
+
+		$this->settings->update( 'limit_dimensions', 'enabled' );
+
+		update_option( self::NEW_USER_DEFAULTS_UPDATED, 'yes' );
 	}
 	/**
 	 * Adds Optimole tag to admin bar

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -221,7 +221,11 @@ class Optml_Admin {
 		$bgclasses             = empty( $bgclasses ) ? '' : sprintf( '"%s"', implode( '","', (array) $bgclasses ) );
 		$watcher_classes       = empty( $watcher_classes ) ? '' : sprintf( '"%s"', implode( '","', (array) $watcher_classes ) );
 		$default_network       = ( $this->settings->get( 'network_optimization' ) === 'enabled' );
-		$retina_ready          = ! ( $this->settings->get( 'retina_images' ) === 'enabled' );
+		$limit_dimensions      = $this->settings->get( 'limit_dimensions' ) === 'enabled';
+		$limit_width           = $this->settings->get( 'limit_width' );
+		$limit_height          = $this->settings->get( 'limit_height' );
+		$retina_ready          = $limit_dimensions ||
+								 ! ( $this->settings->get( 'retina_images' ) === 'enabled' );
 		$scale_is_disabled     = ( $this->settings->get( 'scale' ) === 'enabled' );
 		$native_lazy_enabled   = ( $this->settings->get( 'native_lazyload' ) === 'enabled' );
 		$output                = sprintf(
@@ -264,7 +268,9 @@ class Optml_Admin {
 								backgroundLazySelectors: "%s",
 								network_optimizations: %s,
 								ignoreDpr: %s,
-								quality: %d
+								quality: %d,
+								maxWidth: %d,
+								maxHeight: %d,
 							}
 						}(window, document));
 					document.addEventListener( "DOMContentLoaded", function() {
@@ -291,7 +297,9 @@ class Optml_Admin {
 			addcslashes( wp_strip_all_tags( $lazyload_bg_selectors ), '"' ),
 			defined( 'OPTML_NETWORK_ON' ) && constant( 'OPTML_NETWORK_ON' ) ? ( OPTML_NETWORK_ON ? 'true' : 'false' ) : ( $default_network ? 'true' : 'false' ),
 			$retina_ready ? 'true' : 'false',
-			$this->settings->get_numeric_quality()
+			$this->settings->get_numeric_quality(),
+			$limit_width,
+			$limit_height
 		);
 		echo $output;
 	}
@@ -920,6 +928,9 @@ The root cause might be either a security plugin which blocks this feature or so
 				'enable_resize_smart_title'         => __( 'Enable Smart Cropping', 'optimole-wp' ),
 				'enable_retina_desc'                => __( 'Deliver retina ready images to your visitors', 'optimole-wp' ),
 				'enable_retina_title'               => __( 'Enable Retina images', 'optimole-wp' ),
+				'enable_limit_dimensions_desc'      => __( 'This feature allows you to set a maximum width or height for images on your website, automatically resizing larger images to fit within the defined limits while maintaining the original aspect ratio.', 'optimole-wp' ),
+				'enable_limit_dimensions_title'     => __( 'Limit Image Dimensions with max width/height', 'optimole-wp' ),
+				'enable_limit_dimensions_notice'    => __( 'When you enable this feature to define a max width or height for image resizing, please note that DPR (retina) images will be disabled. This is done to ensure consistency in image dimensions across your website. Although this may result in slightly lower image quality for high-resolution displays, it will help maintain uniform image sizes, improving your website\'s overall layout and potentially boosting performance. ', 'optimole-wp' ),
 				'image_sizes_title'                 => __( 'Your cropped image sizes', 'optimole-wp' ),
 				'enabled'                           => __( 'Enabled', 'optimole-wp' ),
 				'exclude_class_desc'                => sprintf( __( '%1$sImage tag%2$s contains class', 'optimole-wp' ), '<strong>', '</strong>' ),

--- a/inc/app_replacer.php
+++ b/inc/app_replacer.php
@@ -69,6 +69,24 @@ abstract class Optml_App_Replacer {
 	 */
 	protected $max_height = 3000;
 	/**
+	 * Defines if the dimensions should be limited when images are served.
+	 *
+	 * @var int
+	 */
+	protected $limit_dimensions_enabled = false;
+	/**
+	 * Defines which is the maximum width accepted when images are served.
+	 *
+	 * @var int
+	 */
+	protected $limit_width = 1920;
+	/**
+	 * Defines which is the maximum height accepted when images are served.
+	 *
+	 * @var int
+	 */
+	protected $limit_height = 1080;
+	/**
 	 * Defines if css minification should be used.
 	 *
 	 * @var int
@@ -141,6 +159,8 @@ abstract class Optml_App_Replacer {
 	 * @var string Cache Buster value.
 	 */
 	protected $active_cache_buster_assets = '';
+
+	const DIRECT_UPLOAD_SOURCE = 'directUpload';
 
 	/**
 	 * Returns possible src attributes.
@@ -404,7 +424,9 @@ abstract class Optml_App_Replacer {
 
 		$this->possible_sources = $this->extract_domain_from_urls(
 			array_merge(
-				[ get_home_url() ],
+				[
+					get_home_url(),
+				],
 				array_values( $this->site_mappings ),
 				array_keys( $this->site_mappings )
 			)
@@ -429,6 +451,12 @@ abstract class Optml_App_Replacer {
 
 		$this->max_height = $this->settings->get( 'max_height' );
 		$this->max_width  = $this->settings->get( 'max_width' );
+
+		$this->limit_dimensions_enabled = $this->settings->get( 'limit_dimensions' ) === 'enabled';
+		if ( $this->limit_dimensions_enabled ) {
+			$this->limit_height = $this->settings->get( 'limit_height' );
+			$this->limit_width  = $this->settings->get( 'limit_width' );
+		}
 
 		$this->is_css_minify_on = ( $this->settings->get( 'css_minify' ) === 'enabled' ) ? 1 : 0;
 		$this->is_js_minify_on  = ( $this->settings->get( 'js_minify' ) === 'enabled' ) ? 1 : 0;

--- a/inc/app_replacer.php
+++ b/inc/app_replacer.php
@@ -160,8 +160,6 @@ abstract class Optml_App_Replacer {
 	 */
 	protected $active_cache_buster_assets = '';
 
-	const DIRECT_UPLOAD_SOURCE = 'directUpload';
-
 	/**
 	 * Returns possible src attributes.
 	 *

--- a/inc/main.php
+++ b/inc/main.php
@@ -83,7 +83,6 @@ final class Optml_Main {
 			add_filter( 'optimole_wp_feedback_review_message', [ __CLASS__, 'change_review_message' ] );
 			add_filter( 'optimole_wp_logger_heading', [ __CLASS__, 'change_review_message' ] );
 			add_filter( 'optml_default_settings', [ __CLASS__, 'change_lazyload_default' ] );
-			add_filter( 'optml_default_settings', [ __CLASS__, 'change_limits_default' ] );
 			add_filter( 'optml_register_conflicts', [ __CLASS__, 'register_conflicts' ] );
 			self::$_instance          = new self();
 			self::$_instance->manager = Optml_Manager::instance();
@@ -141,26 +140,6 @@ final class Optml_Main {
 		}
 
 		$defaults['lazyload'] = 'enabled';
-
-		return $defaults;
-	}
-
-	/**
-	 * Change limits default for new users.
-	 *
-	 * @param array $defaults Old defaults.
-	 *
-	 * @return array New defaults.
-	 */
-	public static function change_limits_default( $defaults ) {
-		$install_time = get_option( 'optimole_wp_install', 0 );
-
-		// Todo: change this before release to release day.
-		if ( $install_time < 1683870956 ) {
-			return $defaults;
-		}
-
-		$defaults['limit_dimensions'] = 'enabled';
 
 		return $defaults;
 	}

--- a/inc/main.php
+++ b/inc/main.php
@@ -83,6 +83,7 @@ final class Optml_Main {
 			add_filter( 'optimole_wp_feedback_review_message', [ __CLASS__, 'change_review_message' ] );
 			add_filter( 'optimole_wp_logger_heading', [ __CLASS__, 'change_review_message' ] );
 			add_filter( 'optml_default_settings', [ __CLASS__, 'change_lazyload_default' ] );
+			add_filter( 'optml_default_settings', [ __CLASS__, 'change_limits_default' ] );
 			add_filter( 'optml_register_conflicts', [ __CLASS__, 'register_conflicts' ] );
 			self::$_instance          = new self();
 			self::$_instance->manager = Optml_Manager::instance();
@@ -140,6 +141,26 @@ final class Optml_Main {
 		}
 
 		$defaults['lazyload'] = 'enabled';
+
+		return $defaults;
+	}
+
+	/**
+	 * Change limits default for new users.
+	 *
+	 * @param array $defaults Old defaults.
+	 *
+	 * @return array New defaults.
+	 */
+	public static function change_limits_default( $defaults ) {
+		$install_time = get_option( 'optimole_wp_install', 0 );
+
+		// Todo: change this before release to release day.
+		if ( $install_time < 1683870956 ) {
+			return $defaults;
+		}
+
+		$defaults['limit_dimensions'] = 'enabled';
 
 		return $defaults;
 	}

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -64,6 +64,9 @@ class Optml_Settings {
 		'bg_replacer'          => 'enabled',
 		'video_lazyload'       => 'enabled',
 		'retina_images'        => 'disabled',
+		'limit_dimensions'     => 'disabled',
+		'limit_height'         => 1080,
+		'limit_width'          => 1920,
 		'resize_smart'         => 'disabled',
 		'no_script'            => 'disabled',
 		'filters'              => [],
@@ -231,6 +234,7 @@ class Optml_Settings {
 				case 'network_optimization':
 				case 'lazyload_placeholder':
 				case 'retina_images':
+				case 'limit_dimensions':
 				case 'resize_smart':
 				case 'bg_replacer':
 				case 'video_lazyload':
@@ -248,6 +252,8 @@ class Optml_Settings {
 					break;
 				case 'max_width':
 				case 'max_height':
+				case 'limit_height':
+				case 'limit_width':
 					$sanitized_value = $this->to_bound_integer( $value, 100, 5000 );
 					break;
 				case 'quality':
@@ -418,6 +424,9 @@ class Optml_Settings {
 			'lazyload'             => $this->get( 'lazyload' ),
 			'network_optimization' => $this->get( 'network_optimization' ),
 			'retina_images'        => $this->get( 'retina_images' ),
+			'limit_dimensions'     => $this->get( 'limit_dimensions' ),
+			'limit_height'         => $this->get( 'limit_height' ),
+			'limit_width'          => $this->get( 'limit_width' ),
 			'lazyload_placeholder' => $this->get( 'lazyload_placeholder' ),
 			'skip_lazyload_images' => $this->get( 'skip_lazyload_images' ),
 			'bg_replacer'          => $this->get( 'bg_replacer' ),

--- a/inc/url_replacer.php
+++ b/inc/url_replacer.php
@@ -224,14 +224,32 @@ final class Optml_Url_Replacer extends Optml_App_Replacer {
 			}
 			$url = $new_url;
 		}
+
 		if ( ! isset( $args['width'] ) ) {
-			$args['width'] = 'auto';
+			$args['width'] = $this->limit_dimensions_enabled ? $this->limit_width : 'auto';
 		}
 		if ( ! isset( $args['height'] ) ) {
-			$args['height'] = 'auto';
+			$args['height'] = $this->limit_dimensions_enabled ? $this->limit_height : 'auto';
 		}
+
 		$args['width']  = (int) $args['width'];
 		$args['height'] = (int) $args['height'];
+
+		if ( $this->limit_dimensions_enabled ) {
+			if ( $args['width'] > $this->limit_width || $args['height'] > $this->limit_height ) {
+				$scale = min( $this->limit_width / $args['width'], $this->limit_height / $args['height'] );
+
+				if ( $scale < 1 ) {
+					$args['width']  = (int) floor( $scale * $args['width'] );
+					$args['height'] = (int) floor( $scale * $args['height'] );
+				}
+			}
+
+			if ( isset( $args['resize'], $args['resize']['enlarge'] ) ) {
+				$args['resize']['enlarge'] = false;
+			}
+		}
+
 		if ( $args['width'] > 0 && $args['height'] > 0 ) {
 			list( $args['width'], $args['height'] ) = wp_constrain_dimensions( $args['width'], $args['height'], $this->max_width, $this->max_height );
 		} elseif ( $args['width'] > 0 ) {

--- a/tests/test-replacer.php
+++ b/tests/test-replacer.php
@@ -18,6 +18,12 @@ class Test_Replacer extends WP_UnitTestCase {
 	const IMG_TAGS_WITH_SRCSET_RELATIVE = '<img class="alignnone size-full wp-image-26" src="/wp-content/uploads/2019/01/september-2018-wordpress-news-w-codeinwp.jpg" alt="" width="1450" height="740" srcset="/wp-content/uploads/2019/01/september-2018-wordpress-news-w-codeinwp.jpg 1450w, /wp-content/uploads/2019/01/september-2018-wordpress-news-w-codeinwp-300x153.jpg 300w, /wp-content/uploads/2019/01/september-2018-wordpress-news-w-codeinwp-768x392.jpg 768w, /wp-content/uploads/2019/01/september-2018-wordpress-news-w-codeinwp-1024x523.jpg 1024w" sizes="(max-width: 1450px) 100vw, 1450px"> ';
 	const IMG_TAGS_PNG = '<div id="wp-custom-header" class="wp-custom-header"><img src="http://example.org/wp-content/themes/twentyseventeen/assets/images/header.png" width="2000" height="1200" alt="Test" /></div></div>';
 	const IMG_TAGS_GIF = '<div id="wp-custom-header" class="wp-custom-header"><img src="http://example.org/wp-content/themes/twentyseventeen/assets/images/header.gif" width="2000" height="1200" alt="Test" /></div></div>';
+	const IMG_TAGS_LIMIT_DIMENSIONS = [
+		'portrait' => '<div id="wp-custom-header" class="wp-custom-header"><img src="http://example.org/wp-content/themes/twentyseventeen/assets/images/header.jpg" width="2000" height="3000" alt="Test"/></div>',
+		'landscape' => '<div id="wp-custom-header" class="wp-custom-header"><img src="http://example.org/wp-content/themes/twentyseventeen/assets/images/header.jpg" width="3000" height="2000" alt="Test"/></div>',
+		'equal' => '<div id="wp-custom-header" class="wp-custom-header"><img src="http://example.org/wp-content/themes/twentyseventeen/assets/images/header.jpg" width="1920" height="1080" alt="Test"/></div>',
+		'small' => '<div id="wp-custom-header" class="wp-custom-header"><img src="http://example.org/wp-content/themes/twentyseventeen/assets/images/header.jpg" width="150" height="150" alt="Test"/></div>',
+	];
 	const DECODED_UNICODE2 = "/wp-content/uploads/2018/05//umlau1ts_image_a\u0308o\u0308u\u0308.";
 	const DECODED_UNICODE = "/wp-content/uploads/2018/05/umlau1ts_image_äöü";
 	const NOROMAL_URL = "/wp-content/themes/test/assets/images/header";
@@ -170,6 +176,10 @@ class Test_Replacer extends WP_UnitTestCase {
 	}
 
 	public function test_image_tags() {
+		$settings = new Optml_Settings();
+		$settings->update( 'limit_dimensions', 'disabled' );
+
+		Optml_Url_Replacer::instance()->init();
 
 		$found_images = Optml_Manager::parse_images_from_html( self::IMG_TAGS );
 
@@ -200,6 +210,61 @@ class Test_Replacer extends WP_UnitTestCase {
 		$replaced_content = Optml_Manager::instance()->replace_content( self::IMG_URLS );
 
 		$this->assertEquals( 27, substr_count( $replaced_content, 'i.optimole.com' ) );
+	}
+
+	public function test_limit_dimensions_default() {
+		$settings = new Optml_Settings();
+		$settings->update( 'limit_dimensions', 'enabled' );
+
+		Optml_Url_Replacer::instance()->init();
+
+		$replaced_content = Optml_Manager::instance()->process_images_from_content( self::IMG_TAGS_LIMIT_DIMENSIONS['portrait'] );
+		$this->assertStringContainsString( 'i.optimole.com', $replaced_content );
+		$this->assertStringContainsString( '/w:720/', $replaced_content );
+		$this->assertStringContainsString( '/h:1080/', $replaced_content );
+
+		$replaced_content = Optml_Manager::instance()->process_images_from_content( self::IMG_TAGS_LIMIT_DIMENSIONS['landscape'] );
+		$this->assertStringContainsString( 'i.optimole.com', $replaced_content );
+		$this->assertStringContainsString( '/w:1620/', $replaced_content );
+		$this->assertStringContainsString( '/h:1080/', $replaced_content );
+
+		$replaced_content = Optml_Manager::instance()->process_images_from_content( self::IMG_TAGS_LIMIT_DIMENSIONS['equal'] );
+		$this->assertStringContainsString( 'i.optimole.com', $replaced_content );
+		$this->assertStringContainsString( '/w:1920/', $replaced_content );
+		$this->assertStringContainsString( '/h:1080/', $replaced_content );
+
+		$replaced_content = Optml_Manager::instance()->process_images_from_content( self::IMG_TAGS_LIMIT_DIMENSIONS['small'] );
+		$this->assertStringContainsString( 'i.optimole.com', $replaced_content );
+		$this->assertStringContainsString( '/w:150/', $replaced_content );
+		$this->assertStringContainsString( '/h:150/', $replaced_content );
+	}
+
+	public function test_limit_dimensions_custom() {
+		$settings = new Optml_Settings();
+		$settings->update( 'limit_dimensions', 'enabled' );
+		$settings->update( 'limit_height', 600 );
+		$settings->update( 'limit_width', 800 );
+		Optml_Url_Replacer::instance()->init();
+
+		$replaced_content = Optml_Manager::instance()->process_images_from_content( self::IMG_TAGS_LIMIT_DIMENSIONS['portrait'] );
+		$this->assertStringContainsString( 'i.optimole.com', $replaced_content );
+		$this->assertStringContainsString( '/w:400/', $replaced_content );
+		$this->assertStringContainsString( '/h:600/', $replaced_content );
+
+		$replaced_content = Optml_Manager::instance()->process_images_from_content( self::IMG_TAGS_LIMIT_DIMENSIONS['landscape'] );
+		$this->assertStringContainsString( 'i.optimole.com', $replaced_content );
+		$this->assertStringContainsString( '/w:800/', $replaced_content );
+		$this->assertStringContainsString( '/h:533/', $replaced_content );
+
+		$replaced_content = Optml_Manager::instance()->process_images_from_content( self::IMG_TAGS_LIMIT_DIMENSIONS['equal'] );
+		$this->assertStringContainsString( 'i.optimole.com', $replaced_content );
+		$this->assertStringContainsString( '/w:800/', $replaced_content );
+		$this->assertStringContainsString( '/h:450/', $replaced_content );
+
+		$replaced_content = Optml_Manager::instance()->process_images_from_content( self::IMG_TAGS_LIMIT_DIMENSIONS['small'] );
+		$this->assertStringContainsString( 'i.optimole.com', $replaced_content );
+		$this->assertStringContainsString( '/w:150/', $replaced_content );
+		$this->assertStringContainsString( '/h:150/', $replaced_content );
 	}
 
 	public function test_assets_url() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

- Adds a new option to limit max-width and max-height of the served images;
- This option will be enabled by default for new users;
- This will limit the image sizes served on the frontend in the following way:
  - The scale ratio is established by applying the smallest ratio between maxWidth / initialWidth and maxHeight / initialHeight;
  - Then, the image initial w/h is multiplied by this ratio, obtaining the new size for generating the URL w:/h: parameters;
- Images that were served with `w`/`h` auto will be automatically be served with the **w:maxWidth** and **h:maxHeight**


Closes #506.


### How to test the changes in this Pull Request:

1. This should be tested using a staging API key. The version of the JS library that supports this should already be available (https://github.com/Codeinwp/optimole_js_lib/pull/123); 
2. Make sure that the option is enabled under the **Optimole Dashboard > Settings > Resize > Limit Image Dimensions with max width/height** (this option will be enabled by default on an instance where optimole was never installed before today);
3. Make sure you have images that exceed the defined size (1920⨉1080 by default), but you can try a much more visible setup that impacts the image size much more visible - something like 300x200 or similar;
4. The requested URLs for these images on the front end should not exceed the width or the height defined there as long as the option is enabled. This should happen to both the images loaded initially and the lazyloaded ones; 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?