### PR TITLE
chore: fixed gravity and enlarge order conflict #544

### DIFF
--- a/inc/image_properties/resize.php
+++ b/inc/image_properties/resize.php
@@ -167,12 +167,12 @@ class Optml_Resize extends Optml_Property_Type {
 
 		$resize .= sprintf( '/g:%s', $this->gravity );
 
-		if ( $this->enlarge ) {
-			$resize .= '/el:1';
-		}
-
 		if ( $this->gravity === self::GRAVITY_FOCUS_POINT ) {
 			$resize .= sprintf( ':%s:%s', $this->focus_point_x, $this->focus_point_y );
+		}
+
+		if ( $this->enlarge ) {
+			$resize .= '/el:1';
 		}
 
 		return $resize;

--- a/tests/test-replacer.php
+++ b/tests/test-replacer.php
@@ -169,6 +169,18 @@ class Test_Replacer extends WP_UnitTestCase {
 
 	}
 
+	public function test_resize () {
+		$resize = new Optml_Resize([
+			'enlarge' => true,
+			'gravity' => [
+				0.5, 0,
+			],
+			'type' => 'fill',
+		]);
+
+		$this->assertEquals( 'rt:fill/g:fp:0.5:0/el:1', $resize->toString() );
+
+	}
 	public function test_image_tags() {
 
 		$found_images = Optml_Manager::parse_images_from_html( self::IMG_TAGS );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
Changes the order in which `fp` gravity and the `el` options are added in the URL to avoid wrong formats.
 

Closes #544 .

### How to test the changes in this Pull Request:

1. Install the pr plugin.
2. Download this gist as a zip file and install it as a plugin https://gist.github.com/GrigoreMihai/533d47c00647ca56dd18123f4a5e89b9 . The URL's should have the expected format in the issue. 

- [ ] We also need to check that the smart crop, image sizes added with crop from the plugin are not altered in any way. 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
