### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,6 @@ This repository uses conventional [changelog commit](https://github.com/Codeinwp
 
 How to release a new version:
 
-- Clone the master branch
-- Do your changes
 - Send a PR to master and merge it using the following subject message
   - `release: <release short description>` - for patch release
   - `release(minor): <release short description>` - for minor release


### PR DESCRIPTION
Change instances where it says `master` instead of `development` in the CONTRIBUTING.md file.

### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
 

Closes #546.

### How to test the changes in this Pull Request:

1. NA

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
