### PR TITLE
chore: add replacement hook for all elementor's css workflows #542

### DIFF
--- a/inc/compatibilities/elementor_builder.php
+++ b/inc/compatibilities/elementor_builder.php
@@ -22,6 +22,8 @@ class Optml_elementor_builder extends Optml_compatibility {
 	 * Register integration details.
 	 */
 	public function register() {
+		add_action( 'elementor/frontend/after_enqueue_styles', [$this, 'add_src_filter'], PHP_INT_MIN, 1 );
+
 		add_filter( 'elementor/frontend/builder_content/before_enqueue_css_file', [$this, 'add_src_filter'], PHP_INT_MIN, 1 );
 
 		add_filter( 'elementor/frontend/builder_content/before_print_css', [$this, 'remove_src_filter'], PHP_INT_MIN, 1 );
@@ -55,8 +57,13 @@ class Optml_elementor_builder extends Optml_compatibility {
 	 * @uses filter:elementor/frontend/builder_content/before_print_css
 	 */
 	public function remove_src_filter( $with_css ) {
+		//check if the filter was added to avoid duplication
+		if ( ! has_filter( 'wp_get_attachment_image_src', [$this, 'optimize_src'] ) ) {
+			return $with_css;
+		}
 
 		remove_filter( 'wp_get_attachment_image_src', [$this, 'optimize_src'], PHP_INT_MAX );
+
 		return $with_css;
 	}
 	/**
@@ -68,7 +75,7 @@ class Optml_elementor_builder extends Optml_compatibility {
 	 */
 	public function add_src_filter( $css ) {
 
-		add_filter( 'wp_get_attachment_image_src', [$this, 'optimize_src'], PHP_INT_MAX, 4 );
+		add_filter( 'wp_get_attachment_image_src', [$this, 'optimize_src'], PHP_INT_MIN, 4 );
 
 		return $css;
 	}

--- a/inc/compatibilities/elementor_builder.php
+++ b/inc/compatibilities/elementor_builder.php
@@ -57,10 +57,6 @@ class Optml_elementor_builder extends Optml_compatibility {
 	 * @uses filter:elementor/frontend/builder_content/before_print_css
 	 */
 	public function remove_src_filter( $with_css ) {
-		// check if the filter was added to avoid duplication
-		if ( ! has_filter( 'wp_get_attachment_image_src', [$this, 'optimize_src'] ) ) {
-			return $with_css;
-		}
 
 		remove_filter( 'wp_get_attachment_image_src', [$this, 'optimize_src'], PHP_INT_MAX );
 
@@ -75,7 +71,12 @@ class Optml_elementor_builder extends Optml_compatibility {
 	 */
 	public function add_src_filter( $css ) {
 
-		add_filter( 'wp_get_attachment_image_src', [$this, 'optimize_src'], PHP_INT_MIN, 4 );
+		// check if the filter was added to avoid duplication
+		if ( has_filter( 'wp_get_attachment_image_src', [$this, 'optimize_src'] ) ) {
+			return $css;
+		}
+
+		add_filter( 'wp_get_attachment_image_src', [$this, 'optimize_src'], PHP_INT_MAX, 4 );
 
 		return $css;
 	}

--- a/inc/compatibilities/elementor_builder.php
+++ b/inc/compatibilities/elementor_builder.php
@@ -57,7 +57,7 @@ class Optml_elementor_builder extends Optml_compatibility {
 	 * @uses filter:elementor/frontend/builder_content/before_print_css
 	 */
 	public function remove_src_filter( $with_css ) {
-		//check if the filter was added to avoid duplication
+		// check if the filter was added to avoid duplication
 		if ( ! has_filter( 'wp_get_attachment_image_src', [$this, 'optimize_src'] ) ) {
 			return $with_css;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
 Adds the hook to optimize files to the different flow of css saving that elementor is using, by hooking `elementor/frontend/after_enqueue_styles` .

This will only work on elementor versions newer then october 2022 as this is when the filters were added : https://github.com/elementor/elementor/commit/61622de962a9600641bd5ac557517d7ad880282f . I think this is ok as this was added almost one year ago in elementor. 

Closes #542.

### How to test the changes in this Pull Request:

1. Install the pr plugin, neve and elementor.
2. Add some background image in a page built with elementor. 
3. Check that the background image is when viewing the page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
