### PR TITLE
chore: added webp extension exclusion #543

### DIFF
--- a/assets/vue/components/filter-control.vue
+++ b/assets/vue/components/filter-control.vue
@@ -35,6 +35,7 @@
 																		<option value="jpg">.JPG</option>
 																		<option value="png">.PNG</option>
 																		<option value="gif">.GIF</option>
+																		<option value="webp">.WEBP</option>
 																</select>
 														</span>
 										<input v-else v-model="selected_value" class="optml-textarea optml-text-input-border optml-fill-container has-text-left" type="text" :placeholder="this.selected_url_match_type === 'matches' ? 'path' : 'word'">
@@ -84,21 +85,21 @@
 								</div>
 							</div>
 						</div>
-            <div class=" exclusion-filter" v-for="(item, index) in filters[this.FILTER_TYPES.URL_MATCH]">
-              <div>
-                <div class="tags  has-addons">
-                  <div class="tag  optml-light-background is-marginless  is-link has-text-left"><p v-html="strings.exclude_url_match_desc"></p>
-                    &nbsp;<strong>{{index}}</strong>
-                    <a @click="removeRule(FILTER_TYPES.URL_MATCH,index)">
-                      <svg xmlns="http://www.w3.org/2000/svg" width="13" height="16" viewBox="0 0 13 16" fill="none">
-                        <path fill-rule="evenodd" clip-rule="evenodd" d="M9 2H12C12.6 2 13 2.4 13 3V4H0V3C0 2.4 0.5 2 1 2H4C4.2 0.9 5.3 0 6.5 0C7.7 0 8.8 0.9 9 2ZM8 2C7.8 1.4 7.1 1 6.5 1C5.9 1 5.2 1.4 5 2H8ZM11.1 15.1L12 5H1L1.9 15.1C2 15.6 2.4 16 2.9 16H10.1C10.6 16 11.1 15.6 11.1 15.1Z" fill="#757296"/>
-                      </svg>
-                    </a>
-                  </div>
+						<div class=" exclusion-filter" v-for="(item, index) in filters[this.FILTER_TYPES.URL_MATCH]">
+							<div>
+								<div class="tags  has-addons">
+									<div class="tag  optml-light-background is-marginless  is-link has-text-left"><p v-html="strings.exclude_url_match_desc"></p>
+										&nbsp;<strong>{{index}}</strong>
+										<a @click="removeRule(FILTER_TYPES.URL_MATCH,index)">
+											<svg xmlns="http://www.w3.org/2000/svg" width="13" height="16" viewBox="0 0 13 16" fill="none">
+												<path fill-rule="evenodd" clip-rule="evenodd" d="M9 2H12C12.6 2 13 2.4 13 3V4H0V3C0 2.4 0.5 2 1 2H4C4.2 0.9 5.3 0 6.5 0C7.7 0 8.8 0.9 9 2ZM8 2C7.8 1.4 7.1 1 6.5 1C5.9 1 5.2 1.4 5 2H8ZM11.1 15.1L12 5H1L1.9 15.1C2 15.6 2.4 16 2.9 16H10.1C10.6 16 11.1 15.6 11.1 15.1Z" fill="#757296"/>
+											</svg>
+										</a>
+									</div>
 
-                </div>
-              </div>
-            </div>
+								</div>
+							</div>
+						</div>
 						<div class="exclusion-filter"
 								 v-for="(item, index) in filters[this.FILTER_TYPES.FILENAME]">
 							<div>
@@ -157,7 +158,7 @@
 				FILTER_TYPES: {
 					EXT: 'extension',
 					URL: 'page_url',
-          URL_MATCH: 'page_url_match',
+					URL_MATCH: 'page_url_match',
 					FILENAME: 'filename',
 					CLASS: 'class'
 				}

--- a/tests/test-replacer.php
+++ b/tests/test-replacer.php
@@ -638,10 +638,7 @@ class Test_Replacer extends WP_UnitTestCase {
 		$this->assertEquals( 0, substr_count( $replaced_content, 'i.optimole.com' ) );
 		$this->assertStringNotContainsString('data-opt-src', $replaced_content);
 	}
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
+
 	public function test_extension_exclusion()
 	{
 		$settings = new Optml_Settings();
@@ -653,6 +650,9 @@ class Test_Replacer extends WP_UnitTestCase {
 						'jpg' => true,
 					)
 				)));
+		Optml_Url_Replacer::instance()->init();
+		Optml_Tag_Replacer::instance()->init();
+		Optml_Manager::instance()->init();
 		$content = '<div>
 						<img  src="http://example.org/wp-content/uploads/2019/09/Screenshot.png" alt=""/>;
 						<img src="http://example.org/wp-content/uploads/2019/09/img.jpg" alt=""/>;

--- a/tests/test-replacer.php
+++ b/tests/test-replacer.php
@@ -638,6 +638,31 @@ class Test_Replacer extends WP_UnitTestCase {
 		$this->assertEquals( 0, substr_count( $replaced_content, 'i.optimole.com' ) );
 		$this->assertStringNotContainsString('data-opt-src', $replaced_content);
 	}
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_extension_exclusion()
+	{
+		$settings = new Optml_Settings();
+			$settings->update('filters', array(
+				Optml_Settings::FILTER_TYPE_OPTIMIZE => array (
+					Optml_Settings::FILTER_EXT => array (
+						'png' => true,
+						'webp' => true,
+						'jpg' => true,
+					)
+				)));
+		$content = '<div>
+						<img  src="http://example.org/wp-content/uploads/2019/09/Screenshot.png" alt=""/>;
+						<img src="http://example.org/wp-content/uploads/2019/09/img.jpg" alt=""/>;
+						<img  src="http://example.org/img.webp" alt=""/>;
+						<img src="http://example.org/wp-content/uploads/2019/09/Screenshot.png" alt=""/>;
+					</div>';
+		$replaced_content = Optml_Manager::instance()->process_images_from_content($content);
+		$this->assertEquals( 0, substr_count( $replaced_content, 'i.optimole.com' ) );
+		$this->assertStringNotContainsString('data-opt-src', $replaced_content);
+	}
 
 	public function test_strip_metadata() {
 		$replaced_content = Optml_Manager::instance()->replace_content( self::IMG_URLS );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
Adds `webp` to  the extensions exclusions.

The frontend tests are failing for elementor as I uptated the plugin on the testing website, is not related to this.
 

Closes #543 .

### How to test the changes in this Pull Request:

1. Install the pr plugin. 
2. Add some images with `webp` extension to the pages.
3. Go to `Adnvanced > Exclusions` and add the `webp` exclusion. 
4. Now the added webp images should be skipped from optimization.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
