### PR TITLE
chore: added loading eager for lazyload excluded images #762 

### DIFF
--- a/inc/tag_replacer.php
+++ b/inc/tag_replacer.php
@@ -324,11 +324,10 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 		$pattern = '/(?<!\/)' . preg_quote( $original_url, '/' ) . '/i';
 		$replace = $is_slashed ? addcslashes( $new_url, '/' ) : $new_url;
 		if ( $this->settings->get( 'lazyload' ) === 'enabled' && $this->settings->get( 'native_lazyload' ) === 'enabled'
-			&& apply_filters('optml_should_load_eager', '__return_true' ) && ! $this->is_valid_gif( $original_url ) ) {
-			if  (strpos($new_tag, 'loading=') === false ) {
-				$new_tag = preg_replace('/<img/im', $is_slashed ? '<img loading=\"eager\"' : '<img loading="eager"', $new_tag);
-			}
-			else {
+			&& apply_filters( 'optml_should_load_eager', '__return_true' ) && ! $this->is_valid_gif( $original_url ) ) {
+			if ( strpos( $new_tag, 'loading=' ) === false ) {
+				$new_tag = preg_replace( '/<img/im', $is_slashed ? '<img loading=\"eager\"' : '<img loading="eager"', $new_tag );
+			} else {
 				$new_tag = $is_slashed ? str_replace( 'loading=\"lazy\"', 'loading=\"eager\"', $new_tag ) : str_replace( 'loading="lazy"', 'loading="eager"', $new_tag );
 			}
 		}

--- a/inc/tag_replacer.php
+++ b/inc/tag_replacer.php
@@ -323,6 +323,15 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 	public function regular_tag_replace( $new_tag, $original_url, $new_url, $optml_args, $is_slashed = false, $full_tag = '' ) {
 		$pattern = '/(?<!\/)' . preg_quote( $original_url, '/' ) . '/i';
 		$replace = $is_slashed ? addcslashes( $new_url, '/' ) : $new_url;
+		if ( $this->settings->get( 'lazyload' ) === 'enabled' && $this->settings->get( 'native_lazyload' ) === 'enabled' && apply_filters('optml_should_load_eager', '__return_true' ) ) {
+			if  (strpos($new_tag, 'loading=') === false ) {
+				$new_tag = preg_replace('/<img/im', $is_slashed ? '<img loading=\"eager\"' : '<img loading="eager"', $new_tag);
+			}
+			else {
+				$new_tag = $is_slashed ? str_replace( 'loading=\"lazy\"', 'loading=\"eager\"', $new_tag ) : str_replace( 'loading="lazy"', 'loading="eager"', $new_tag );
+			}
+		}
+
 		self::$lazyload_skipped_images ++;
 		return preg_replace( $pattern, $replace, $new_tag );
 	}

--- a/inc/tag_replacer.php
+++ b/inc/tag_replacer.php
@@ -323,7 +323,8 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 	public function regular_tag_replace( $new_tag, $original_url, $new_url, $optml_args, $is_slashed = false, $full_tag = '' ) {
 		$pattern = '/(?<!\/)' . preg_quote( $original_url, '/' ) . '/i';
 		$replace = $is_slashed ? addcslashes( $new_url, '/' ) : $new_url;
-		if ( $this->settings->get( 'lazyload' ) === 'enabled' && $this->settings->get( 'native_lazyload' ) === 'enabled' && apply_filters('optml_should_load_eager', '__return_true' ) ) {
+		if ( $this->settings->get( 'lazyload' ) === 'enabled' && $this->settings->get( 'native_lazyload' ) === 'enabled'
+			&& apply_filters('optml_should_load_eager', '__return_true' ) && ! $this->is_valid_gif( $original_url ) ) {
 			if  (strpos($new_tag, 'loading=') === false ) {
 				$new_tag = preg_replace('/<img/im', $is_slashed ? '<img loading=\"eager\"' : '<img loading="eager"', $new_tag);
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
This will add `loading='eager'` to the first images excluded from lazyload when native lazyload is enabled. Does not add eager loading for GIF images. (added the reasoning for GIF's into the performance details). 

Also provides a filter to disable this just in case some users do not need it. It's also good for testing purposes, the gist for it is here: https://gist.github.com/GrigoreMihai/3e7a74836d7d1212966f86a43f640856 .

We not need to check the excluded count where the code was added because it is checked here: https://github.com/Codeinwp/optimole-wp/blob/master/inc/lazyload_replacer.php#L242 before the added part will be called. 

The frontend tests that are currently failing are because of the testing site elementor update. Once that issue passes qa I will sync this and make sure the tests are passing before merging. 

### Performance details

I tested all the pages from https://optimole-qa.vertisite.cloud/ as we have a lot of different cases there. 

Excepting the gif page on all the pages adding loading eager improved the user experience decreasing the fully loaded time (4secs on the best results). Visually I did not see any changes (bad or good). I will list here some comparations (left without this feature and native lazyload enabled and right with eager loading). 

https://vertis.d.pr/i/jYAtWe , https://vertis.d.pr/i/QDfEyM , https://vertis.d.pr/i/bga9Q3 , https://vertis.d.pr/i/0pktjl, https://vertis.d.pr/i/GracZB 


For gif images adding eager loading will have negative results by increasing the fully loaded time until the gif's are loaded:  https://vertis.d.pr/i/gY63Lm . (the test was done before excluding the gif's from this, left side test is without eager loading)

Considering that it will not be a good idea to eager load big images, I think it is best to exclude gif images from eager loading.  

Closes [#762](https://github.com/Codeinwp/optimole-service/issues/762) .

### How to test the changes in this Pull Request:

1. Install the pr plugin and activate the native lazyload option.
2. Check that the first images excluded from lazyload are having the `loading='eager'` attribute added. 
3. Check that GIF images do not get the `loading='eager'` attribute added.
4. Check that this does not add any visual changes on the pages compared to the previous version. To easily disable and enable the feature the plugin in this gist can be used to disable this: https://gist.github.com/GrigoreMihai/3e7a74836d7d1212966f86a43f640856 . 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
