### PR TITLE
Add plugin conflict notice

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -587,7 +587,7 @@ class Optml_Admin {
 	 * Adds conflicts notice.
 	 */
 	public function add_notice_conflicts() {
-		if ( ! $this->conflicting_plugins->should_show_notice() || ! $this->settings->is_connected() ) {
+		if ( $this->settings->is_connected() || ! $this->conflicting_plugins->should_show_notice() ) {
 			return;
 		}
 

--- a/inc/conflicts/conflicting_plugins.php
+++ b/inc/conflicts/conflicting_plugins.php
@@ -94,10 +94,16 @@ class Optml_Conflicting_Plugins {
 	 *
 	 * @since  3.8.0
 	 * @access private
+	 * @param  boolean $show_dismissed Also show the dismissed plugins.
 	 * @return array
 	 */
-	public function get_conflicting_plugins() {
+	public function get_conflicting_plugins( $show_dismissed = false ) {
 		$conflicting_plugins = $this->get_active_plugins();
+
+		if ( true === $show_dismissed ) {
+			return $conflicting_plugins;
+		}
+
 		$dismissed_conflicts = $this->get_dismissed_notices();
 
 		$conflicting_plugins = array_diff_key( $conflicting_plugins, $dismissed_conflicts );
@@ -190,7 +196,7 @@ class Optml_Conflicting_Plugins {
 			return $plugins;
 		}
 
-		$allowed_plugins = $this->get_conflicting_plugins();
+		$allowed_plugins = $this->get_conflicting_plugins( true );
 
 		$filtered_plugins = [];
 

--- a/inc/conflicts/conflicting_plugins.php
+++ b/inc/conflicts/conflicting_plugins.php
@@ -42,7 +42,14 @@ class Optml_Conflicting_Plugins {
 	 */
 	private function defined_plugins() {
 		$plugins = [
-			'wp-smush'   => 'wp-smushit/wp-smush.php',
+			'wp-smush'     => 'wp-smushit/wp-smush.php',
+			'wp-smush-pro' => 'wp-smush-pro/wp-smush.php',
+			'kraken'       => 'kraken-image-optimizer/kraken.php',
+			'tinypng'      => 'tiny-compress-images/tiny-compress-images.php',
+			'shortpixel'   => 'shortpixel-image-optimiser/wp-shortpixel.php',
+			'ewww'         => 'ewww-image-optimizer/ewww-image-optimizer.php',
+			'ewww-cloud'   => 'ewww-image-optimizer-cloud/ewww-image-optimizer-cloud.php',
+			'imagerecycle' => 'imagerecycle-pdf-image-compression/wp-image-recycle.php',
 			// 'plugin-slug' => 'plugin-folder/plugin-file.php'
 		];
 

--- a/inc/conflicts/conflicting_plugins.php
+++ b/inc/conflicts/conflicting_plugins.php
@@ -50,6 +50,7 @@ class Optml_Conflicting_Plugins {
 			'ewww'         => 'ewww-image-optimizer/ewww-image-optimizer.php',
 			'ewww-cloud'   => 'ewww-image-optimizer-cloud/ewww-image-optimizer-cloud.php',
 			'imagerecycle' => 'imagerecycle-pdf-image-compression/wp-image-recycle.php',
+			'imagify'      => 'imagify/imagify.php',
 			// 'plugin-slug' => 'plugin-folder/plugin-file.php'
 		];
 

--- a/inc/conflicts/conflicting_plugins.php
+++ b/inc/conflicts/conflicting_plugins.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * The Conflicting Plugins class, documents and displays dashboard notice for conflicting plugins.
+ *
+ * @package \Optimole\Inc\Conflicts
+ * @author  Hardeep Asrani <hardeep@optimole.com>
+ */
+
+/**
+ * Class Optml_Conflicting_Plugins
+ *
+ * @since 3.8.0
+ */
+class Optml_Conflicting_Plugins {
+
+	/**
+	 * Option key.
+	 *
+	 * @since  3.8.0
+	 * @access private
+	 * @var    string
+	 */
+	private $option_main = 'optml_dismissed_plugin_conflicts';
+
+	/**
+	 * Optml_Conflicting_Plugins constructor.
+	 *
+	 * @since  3.8.0
+	 * @access public
+	 */
+	public function __construct() {
+		add_action( 'wp_ajax_optml_dismiss_conflict_notice', [ $this, 'dismiss_notice' ] );
+		add_filter( 'all_plugins', [ $this, 'filter_conflicting_plugins' ] );
+	}
+
+	/**
+	 * Define conflicting plugins.
+	 *
+	 * @since  3.8.0
+	 * @access private
+	 * @return array
+	 */
+	private function defined_plugins() {
+		$plugins = [
+			'wp-smush'   => 'wp-smushit/wp-smush.php',
+			// 'plugin-slug' => 'plugin-folder/plugin-file.php'
+		];
+
+		return apply_filters( 'optml_conflicting_plugins', $plugins );
+	}
+
+	/**
+	 * Get a list of active conflicting plugins.
+	 *
+	 * @since  3.8.0
+	 * @access private
+	 * @return array
+	 */
+	private function get_active_plugins() {
+		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
+		$conflicting_plugins = $this->defined_plugins();
+		return array_filter( $conflicting_plugins, 'is_plugin_active' );
+	}
+
+	/**
+	 * Get a list of dismissed conflicting plugins.
+	 *
+	 * @since  3.8.0
+	 * @access private
+	 * @return array
+	 */
+	private function get_dismissed_notices() {
+		$dismissed_conflicts = get_option( $this->option_main, '{}' );
+		$dismissed_conflicts = json_decode( $dismissed_conflicts, true );
+
+		if ( empty( $dismissed_conflicts ) ) {
+			return [];
+		}
+
+		return $dismissed_conflicts;
+	}
+
+	/**
+	 * Get a list of undismissed conflicting plugins.
+	 *
+	 * @since  3.8.0
+	 * @access private
+	 * @return array
+	 */
+	public function get_conflicting_plugins() {
+		$conflicting_plugins = $this->get_active_plugins();
+		$dismissed_conflicts = $this->get_dismissed_notices();
+
+		$conflicting_plugins = array_diff_key( $conflicting_plugins, $dismissed_conflicts );
+
+		return $conflicting_plugins;
+	}
+
+	/**
+	 * Checks if there are any conflicting plugins.
+	 *
+	 * @since  3.8.0
+	 * @access private
+	 * @return boolean
+	 */
+	private function has_conflicting_plugins() {
+		$conflicting_plugins = $this->get_conflicting_plugins();
+
+		return ! empty( $conflicting_plugins );
+	}
+
+	/**
+	 * Check if we should show the notice.
+	 *
+	 * @since  3.8.0
+	 * @access public
+	 * @return bool Should show?
+	 */
+	public function should_show_notice() {
+		if ( ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+			return false;
+		}
+
+		if ( is_network_admin() ) {
+			return false;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+
+		$current_screen = get_current_screen();
+
+		if ( empty( $current_screen ) ) {
+			return false;
+		}
+
+		if ( ! $this->has_conflicting_plugins() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Filter conflicting plugins.
+	 * It will appear at wp-admin/plugins.php?optimole_conflicts
+	 *
+	 * @since  3.8.0
+	 * @access public
+	 * @param  array $plugins List of plugins.
+	 * @return array
+	 */
+	public function filter_conflicting_plugins( $plugins ) {
+		if ( ! isset( $_GET['optimole_conflicts'] ) ) {
+			return $plugins;
+		}
+
+		$allowed_plugins = $this->get_conflicting_plugins();
+
+		$filtered_plugins = [];
+
+		foreach ( $plugins as $plugin_file => $plugin_data ) {
+			if ( in_array( $plugin_file, $allowed_plugins, true ) ) {
+				$filtered_plugins[ $plugin_file ] = $plugin_data;
+			}
+		}
+
+		return $filtered_plugins;
+	}
+
+	/**
+	 * Update the option value using AJAX
+	 *
+	 * @since  3.8.0
+	 * @access public
+	 */
+	public function dismiss_notice() {
+		if ( ! isset( $_POST['nonce'] ) ) {
+			$response = [
+				'success' => false,
+				'message' => 'Missing nonce or value.',
+			];
+			wp_send_json( $response );
+			wp_die();
+		}
+
+		$nonce = sanitize_text_field( $_POST['nonce'] );
+
+		if ( ! wp_verify_nonce( $nonce, 'optml_dismiss_conflict_notice' ) ) {
+			$response = [
+				'success' => false,
+				'message' => 'Invalid nonce.',
+			];
+			wp_send_json( $response );
+			wp_die();
+		}
+
+		$options = get_option( $this->option_main, '{}' );
+		$options = json_decode( $options, true );
+
+		if ( empty( $options ) ) {
+			$options = [];
+		}
+
+		$conflicting_plugins = $this->get_conflicting_plugins();
+
+		foreach ( $conflicting_plugins as $slug => $file ) {
+			$conflicting_plugins[ $slug ] = true;
+		}
+
+		$options = array_merge( $options, $conflicting_plugins );
+
+		update_option( $this->option_main, wp_json_encode( $options ) );
+
+		$response = [
+			'success' => true,
+		];
+
+		wp_send_json( $response );
+		wp_die();
+	}
+}

--- a/tests/test-plugin-conflicts.php
+++ b/tests/test-plugin-conflicts.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * WordPress unit test plugin.
+ *
+ * @package     Optimole-WP
+ * @subpackage  Tests
+ * @copyright   Copyright (c) 2023, ThemeIsle
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class Test_Plugin_Conflicts.
+ */
+class Test_Plugin_Conflicts extends WP_UnitTestCase {
+	public static $conflicts;
+
+	public function setUp(): void {
+		parent::setUp();
+        self::$conflicts = new Optml_Conflicting_Plugins();
+
+        add_filter( 'optml_conflicting_active_plugins', function ( $plugins ) {
+            return [
+                'wp-smush'     => 'wp-smushit/wp-smush.php',
+                'wp-smush-pro' => 'wp-smush-pro/wp-smush.php'
+            ];
+        } );
+	}
+
+	public function test_has_conflicting_plugins() {
+        $this->assertTrue( self::$conflicts->has_conflicting_plugins() );
+        $this->assertCount( 2, self::$conflicts->get_conflicting_plugins() );
+	}
+
+	public function test_dismissed_conflicts() {
+        self::$conflicts->dismiss_conflicting_plugins();
+        $this->assertCount( 0, self::$conflicts->get_conflicting_plugins() );
+	}
+
+	public function test_new_dismissed_conflicts() {
+        self::$conflicts->dismiss_conflicting_plugins();
+
+        add_filter( 'optml_conflicting_active_plugins', function ( $plugins ) {
+            $plugins['kraken'] = 'kraken-image-optimizer/kraken.php';
+            return $plugins;
+        } );
+
+        $this->assertCount( 1, self::$conflicts->get_conflicting_plugins() );
+	}
+}

--- a/tests/test-plugin-conflicts.php
+++ b/tests/test-plugin-conflicts.php
@@ -45,5 +45,6 @@ class Test_Plugin_Conflicts extends WP_UnitTestCase {
         } );
 
         $this->assertCount( 1, self::$conflicts->get_conflicting_plugins() );
+        $this->assertCount( 3, self::$conflicts->get_conflicting_plugins( true ) );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

This adds notices when a conflicting plugin is installed alongside Optimole WP. The notices are dismissable and we also record for which plugin they have been dismissed, in case you install a new plugin that also poses a conflict.
 
This should help showcase the feature: https://www.loom.com/share/6b070c8d0d524145a7b9a1b6633d409d

Closes https://github.com/Codeinwp/optimole-service/issues/761.

### How to test the changes in this Pull Request:

1. Install few of the conflicting plugins, the list is here: https://github.com/Codeinwp/optimole-wp/blob/a82c214ab1d574a4c4627f2cf0a1af23c4d9d265/inc/conflicts/conflicting_plugins.php#L45-L52
2. You should see a Dashboard notice that should be dismissable.
3. After dismissing the notice, if you install any new conflicting plugin, the notice should appear again but this time only with the conflicting plugin.
4. This only appears if the user isn't connected to Optimole.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
