### PR TITLE
Fix/848

### DIFF
--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -335,7 +335,7 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 		$filename = wp_basename( $data['guid'] );
 		$ext = $this->get_ext( $filename );
 		// skip if the file is not an image
-		if ( ! isset( Optml_Config::$all_extensions[ $ext ] ) && ! in_array( $ext, ['jpg', 'jpeg', 'jpe'] ) ) {
+		if ( ! isset( Optml_Config::$all_extensions[ $ext ] ) && ! in_array( $ext, ['jpg', 'jpeg', 'jpe'], true ) ) {
 			return $data;
 		}
 

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -1205,6 +1205,7 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 
 		// check if the current filename is the last deduplicated filename
 		if ( ! empty( self::$last_deduplicated ) && strpos( $no_ext_filename, str_replace( '.' . $extension, '', self::$last_deduplicated ) ) !== false ) {
+			// replace the file with the original before deduplication to get the path where the image is uploaded
 			$local_file = str_replace( $file_name, self::$last_deduplicated, $local_file );
 			$original_name = self::$last_deduplicated;
 			self::$last_deduplicated = false;

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -351,8 +351,10 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 			// and use it to replace the filename in the guid
 			$no_ext_filename = str_replace( '.' . $ext, '', $filename );
 
+			$no_ext_filename_sanitized = sanitize_title( $no_ext_filename );
+
 			// get the deduplication addition from the database post_name
-			$diff = str_replace( strtolower( $no_ext_filename ), '', $sanitized_post_name );
+			$diff = str_replace( strtolower( $no_ext_filename_sanitized ), '', $sanitized_post_name );
 
 			// create the deduplicated filename
 			$to_replace_with = $no_ext_filename . $diff . '.' . $ext;

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -293,9 +293,9 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 		if ( ! empty( self::$current_file_deduplication ) && stripos( self::$current_file_deduplication, $no_ext_file_name ) !== false ) {
 			$file = str_replace( $file_name, self::$current_file_deduplication, $file );
 			// we need to store the lowercase version of the filename we replaced to check when uploading the image if it was deduplicated
-			self::$last_deduplicated = strtolower( $file_name );
+			self::$last_deduplicated = $file_name;
 			// we also need the original filename before deduplication in order to delete it and upload to our servers
-			self::$last_deduplicated_original = $file_name;
+			// self::$last_deduplicated_original = $file_name;
 			self::$current_file_deduplication = false;
 		}
 		if ( OPTML_DEBUG_MEDIA ) {
@@ -329,19 +329,34 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 			do_action( 'optml_log', 'data before' );
 			do_action( 'optml_log', $data );
 		}
-		if ( ! empty( $data['guid'] ) ) {
-			$filename = wp_basename( $data['guid'] );
-			$ext = $this->get_ext( $filename );
-			// on some instances (just unit tests) the post name has the extension appended like this : `image-1-jpg`
-			// we remove that as it is redundant for the file name deduplication we are using it
-			$sanitized_post_name = str_replace( '-' . $ext, '', $data['post_name'] );
+		if ( empty( $data['guid'] ) ) {
+			return $data;
 		}
+
+		$filename = wp_basename( $data['guid'] );
+		$ext = $this->get_ext( $filename );
+		// skip if the file is not an image
+		if ( ! isset( Optml_Config::$all_extensions[ $ext ] ) && ! in_array( $ext, ['jpg', 'jpeg', 'jpe'] ) ) {
+			return $data;
+		}
+
+		// on some instances (just unit tests) the post name has the extension appended like this : `image-1-jpg`
+		// we remove that as it is redundant for the file name deduplication we are using it
+		$sanitized_post_name = str_replace( '-' . $ext, '', $data['post_name'] );
+
 		// with the wp deduplication working the post_title is identical to the post_name
 		// so when they are different it means we need to deduplicate using the post_name
 		if ( ! empty( $data['post_name'] ) && $data['post_title'] !== $sanitized_post_name ) {
 			// we append the extension to the post_name to create a filename
 			// and use it to replace the filename in the guid
-			$to_replace_with = $sanitized_post_name . '.' . $ext;
+			$no_ext_filename = str_replace( '.' . $ext, '', $filename );
+
+			// get the deduplication addition from the database post_name
+			$diff = str_replace( strtolower( $no_ext_filename ), '', $sanitized_post_name );
+
+			// create the deduplicated filename
+			$to_replace_with = $no_ext_filename . $diff . '.' . $ext;
+
 			$data['guid'] = str_replace( $filename, $to_replace_with, $data['guid'] );
 			// we store the deduplication to be used and add the filter for updating the attached_file meta
 			self::$current_file_deduplication = $to_replace_with;
@@ -1189,9 +1204,8 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 
 		// check if the current filename is the last deduplicated filename
 		if ( ! empty( self::$last_deduplicated ) && strpos( $no_ext_filename, str_replace( '.' . $extension, '', self::$last_deduplicated ) ) !== false ) {
-			// replace the file with the original before deduplication to get the path where the image is uploaded
-			$local_file = str_replace( $file_name, self::$last_deduplicated_original, $local_file );
-			$original_name = self::$last_deduplicated_original;
+			$local_file = str_replace( $file_name, self::$last_deduplicated, $local_file );
+			$original_name = self::$last_deduplicated;
 			self::$last_deduplicated = false;
 		}
 		if ( OPTML_DEBUG_MEDIA ) {

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -292,10 +292,9 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 		// we replace the updated filename with the deduplicated filename
 		if ( ! empty( self::$current_file_deduplication ) && stripos( self::$current_file_deduplication, $no_ext_file_name ) !== false ) {
 			$file = str_replace( $file_name, self::$current_file_deduplication, $file );
-			// we need to store the lowercase version of the filename we replaced to check when uploading the image if it was deduplicated
+			// we need to store the filename we replaced to check when uploading the image if it was deduplicated
 			self::$last_deduplicated = $file_name;
-			// we also need the original filename before deduplication in order to delete it and upload to our servers
-			// self::$last_deduplicated_original = $file_name;
+
 			self::$current_file_deduplication = false;
 		}
 		if ( OPTML_DEBUG_MEDIA ) {

--- a/tests/test-media.php
+++ b/tests/test-media.php
@@ -163,7 +163,7 @@ class Test_Media extends WP_UnitTestCase {
 	public function test_duplicated_image() {
 
 		$content =  wp_get_attachment_image( self::$sample_attachement_upper_case );
-		$this->assertEquals(  "<img width=\"150\" height=\"150\" src=\"https://example.i.optimole.com/w:150/h:150/q:mauto/rt:fill/g:ce/process:46/id:579c7f7707ce87caa65fdf50c238a117/http://example.org/1PQ7p-2.jpg.jpg\" class=\"attachment-thumbnail size-thumbnail\" alt=\"\" decoding=\"async\" />", $content);
+		$this->assertEquals(  "<img width=\"150\" height=\"150\" src=\"https://example.i.optimole.com/w:150/h:150/q:mauto/rt:fill/g:ce/process:46/id:579c7f7707ce87caa65fdf50c238a117/http://example.org/1PQ7p-2.jpg\" class=\"attachment-thumbnail size-thumbnail\" alt=\"\" decoding=\"async\" />", $content);
 	}
 	public function test_page_images_process() {
 

--- a/tests/test-media.php
+++ b/tests/test-media.php
@@ -163,7 +163,7 @@ class Test_Media extends WP_UnitTestCase {
 	public function test_duplicated_image() {
 
 		$content =  wp_get_attachment_image( self::$sample_attachement_upper_case );
-		$this->assertEquals(  "<img width=\"150\" height=\"150\" src=\"https://example.i.optimole.com/w:150/h:150/q:mauto/rt:fill/g:ce/process:46/id:579c7f7707ce87caa65fdf50c238a117/http://example.org/1pq7p-2.jpg\" class=\"attachment-thumbnail size-thumbnail\" alt=\"\" decoding=\"async\" />", $content);
+		$this->assertEquals(  "<img width=\"150\" height=\"150\" src=\"https://example.i.optimole.com/w:150/h:150/q:mauto/rt:fill/g:ce/process:46/id:579c7f7707ce87caa65fdf50c238a117/http://example.org/1PQ7p-2.jpg.jpg\" class=\"attachment-thumbnail size-thumbnail\" alt=\"\" decoding=\"async\" />", $content);
 	}
 	public function test_page_images_process() {
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
Previously we were using the `post_name` which is unique against the database since we were not having the files on the users server to use the default WP deduplication, but this was causing the filenames to be lower case. 

I updated the flow to use the `post_name` only for extracting the deduplication sufix eg: `-7` . 

Regarding the zips issue this was because we were doing this for every attached file that triggered the`update_attached_file` hook. To fix this I added a check for the file extension to be in our approved list of extensions we process. 

Closes [#848](https://github.com/Codeinwp/optimole-service/issues/848) .

### How to test the changes in this Pull Request:

1. Install the pr plugin and enable the offload media option. 
2. Add images with capitals laters in name. The original name should be kept and only the deduplication added.  
3. Check that zips or other file types uploads are not having the naming changed by us. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
