### PR TITLE
fix: bust dashboard cache and refresh stats when banner gets toggled

### DIFF
--- a/assets/src/parts/connected/settings/index.js
+++ b/assets/src/parts/connected/settings/index.js
@@ -27,7 +27,7 @@ const Settings = ({
 	setTab
 }) => {
 	const {
-		getSettings,
+		siteSettings,
 		isLoading,
 		extraVisits
 	} = useSelect( select => {
@@ -38,15 +38,17 @@ const Settings = ({
 			extraVisits
 		} = select( 'optimole' );
 
+		const siteSettings = getSiteSettings();
+
 		return {
-			getSettings: getSiteSettings,
-			extraVisits: getSiteSettings( 'banner_frontend' ),
+			siteSettings,
+			extraVisits: siteSettings['banner_frontend'],
 			isLoading: isLoading(),
 			queryArgs: getQueryArgs()
 		};
 	});
 
-	const [ settings, setSettings ] = useState( getSettings() );
+	const [ settings, setSettings ] = useState( siteSettings );
 	const [ canSave, setCanSave ] = useState( false );
 	const [ showSample, setShowSample ] = useState( false );
 	const [ isSampleLoading, setIsSampleLoading ] = useState( false );
@@ -74,7 +76,8 @@ const Settings = ({
 	};
 
 	const onSaveSettings = () => {
-		saveSettings( settings );
+		saveSettings( settings, siteSettings['banner_frontend'] !== settings['banner_frontend']);
+
 		setCanSave( false );
 	};
 

--- a/assets/src/utils/api.js
+++ b/assets/src/utils/api.js
@@ -353,9 +353,8 @@ export const retrieveOptimizedImages = ( callback = () => {}) => {
 		});
 };
 
-export const saveSettings = ( settings ) => {
+export const saveSettings = ( settings, refreshStats = false ) => {
 	setIsLoading( true );
-
 	apiFetch({
 		path: optimoleDashboardApp.routes['update_option'],
 		method: 'POST',
@@ -370,6 +369,11 @@ export const saveSettings = ( settings ) => {
 				setSiteSettings( response.data );
 				console.log( '%c Settings Saved.', 'color: #59B278' );
 			}
+		}).then( () => {
+			if ( ! refreshStats ) {
+				return;
+			}
+			requestStatsUpdate();
 		})
 		.catch( error => {
 			setIsLoading( false );

--- a/inc/api.php
+++ b/inc/api.php
@@ -95,12 +95,12 @@ final class Optml_Api {
 	 *
 	 * @return array|bool|string
 	 */
-	public function update_extra_visits( $api_key = '', $status = 'enabled' ) {
+	public function update_extra_visits( $api_key = '', $status = 'enabled', $application = '' ) {
 		if ( ! empty( $api_key ) ) {
 			$this->api_key = $api_key;
 		}
 
-		return $this->request( '/optml/v2/account/extra_visits', 'POST', [ 'extra_visits' => $status ] );
+		return $this->request( '/optml/v2/account/extra_visits', 'POST', [ 'extra_visits' => $status, 'application' => $application ] );
 	}
 
 	/**

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -423,8 +423,10 @@ class Optml_Settings {
 		$opt = $this->options;
 
 		if ( $key === 'banner_frontend' ) {
-			$api      = new Optml_Api();
-			$response = $api->update_extra_visits( $opt['api_key'], $value );
+			$api          = new Optml_Api();
+			$service_data = $this->get( 'service_data' );
+			$application  = isset( $service_data['cdn_key'] ) ? $service_data['cdn_key'] : '';
+			$response     = $api->update_extra_visits( $opt['api_key'], $value, $application );
 		}
 
 		$opt[ $key ] = $value;


### PR DESCRIPTION
Bust dashboard cache and refresh stats when banner gets toggled 

### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
- Adds mechanism to refresh stats when dashboard settings are saved;
- Sends application as request param when toggling the visits banner - we need that to clear the cache;
- Refreshes stats after the visits banner setting is toggled;

Closes Codeinwp/optimole-service#100.

### How to test the changes in this Pull Request:

1. After toggling the visits banner on or off, we request a stats update so the visits quota should update:
<img width="961" alt="image" src="https://github.com/Codeinwp/optimole-wp/assets/15010186/b1d3d61e-6966-4ead-b787-bb3b20e8da55">

3. 25k with the option on, 5k with the option off for free users (essentially, it adds 20k visits to the total quota);
4. The 5-minute cache window should not exist for the site where the toggle is happening in this particular case - so the dashboard is updated, but for other sites connected with the same API key, it will still take 5 minutes until the cache is cleared; 
