### PR TITLE
Add support link for Premium users

### DIFF
--- a/assets/src/parts/connected/Sidebar.js
+++ b/assets/src/parts/connected/Sidebar.js
@@ -9,6 +9,8 @@ import {
 
 import { useSelect } from '@wordpress/data';
 
+import { addQueryArgs } from '@wordpress/url';
+
 const reasons = [
 	optimoleDashboardApp.strings.upgrade.reason_1,
 	optimoleDashboardApp.strings.upgrade.reason_2,
@@ -69,7 +71,7 @@ const Sidebar = () => {
 				/>
 			</div>
 
-			{ 'free' === plan && (
+			{ 'free' === plan ? (
 				<div
 					className="bg-info flex flex-col text-white border-0 rounded-lg shadow-md p-8 bg-promo bg-no-repeat"
 					style={ {
@@ -90,7 +92,6 @@ const Sidebar = () => {
 						) ) }
 					</ul>
 
-
 					<Button
 						variant="link"
 						className="optml__button flex w-full justify-center font-bold min-h-40 !no-underline !text-white !bg-opaque-black !rounded"
@@ -100,6 +101,19 @@ const Sidebar = () => {
 						{ optimoleDashboardApp.strings.upgrade.cta }
 					</Button>
 				</div>
+			) : (
+				<Button
+					variant="default"
+					className="bg-white flex font-bold border-0 rounded-lg shadow-md p-8 text-sm justify-center"
+					href={ addQueryArgs( 'https://optimole.com/contact/', {
+						contact_name: window.optimoleDashboardApp.user_data.display_name,
+						contact_email: optimoleDashboardApp.user_data.user_email,
+						contact_website: optimoleDashboardApp.home_url
+					}) }
+					target="_blank"
+				>
+					{ optimoleDashboardApp.strings.premium_support }
+				</Button>
 			) }
 		</div>
 	);

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -958,6 +958,7 @@ If you still want to disconnect click the button below.',
 			'private_cdn_url'                => __( 'IMAGES DOMAIN', 'optimole-wp' ),
 			'existing_user'                  => __( 'Existing user?', 'optimole-wp' ),
 			'notification_message_register'  => __( 'We sent you the API Key in the email. Add it below to connect to Optimole.', 'optimole-wp' ),
+			'premium_support'                => __( 'Access our Premium Support', 'optimole-wp' ),
 			'account_needed_title'           => sprintf(
 				__( 'In order to get access to free image optimization service you will need an API key from %s.', 'optimole-wp' ),
 				' <a href="https://dashboard.optimole.com/register" target="_blank">optimole.com</a>'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

This adds a support button to the Sidebar if you view the plugin dashboard as a premium user and autofills the contact form on the website. 

<img width="1277" alt="Screenshot 2023-06-21 at 4 20 47 PM" src="https://github.com/Codeinwp/optimole-wp/assets/2649903/b1f65ef2-825e-4097-a155-6590daf6b475">


Closes [#754](https://github.com/Codeinwp/optimole-service/issues/754).

### How to test the changes in this Pull Request:

1. Connect to Optimole using a non-free account.
2. You should see a support button in the Optimole dashboard sidebar.
3. Clicking on it should load the contact page on the Optimole website with the details pre-filled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
