### PR TITLE
fix: compatibilities loaded even when service is disconnected 

### DIFF
--- a/inc/compatibilities/elementor_builder.php
+++ b/inc/compatibilities/elementor_builder.php
@@ -15,7 +15,7 @@ class Optml_elementor_builder extends Optml_compatibility {
 	function should_load() {
 		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
-		return is_plugin_active( 'elementor/elementor.php' );
+		return Optml_Main::instance()->admin->settings->is_connected() && is_plugin_active( 'elementor/elementor.php' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
Checks that the plugin is connected to the service before running Elementor compatibilities. The warning should not happen anymore.

![image](https://github.com/Codeinwp/optimole-wp/assets/15010186/896f0a0c-ff35-4d60-bc7c-6676800dfaf4)

 

Closes #572.

### How to test the changes in this Pull Request:

1. Use PHP 7.4 (I replicated it with PHP 7.4.33); 
2. Have Elementor installed and create a page using it, containing an image;
3. Install and activate Optimole but don't connect it;
2. Go to the Elementor page created initially, and there should be no warning;
3. Elementor compatibilities should still work fine when the plugin is connected;

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
 
