### PR TITLE
Add CSAT

### DIFF
--- a/assets/src/parts/connected/CSAT.js
+++ b/assets/src/parts/connected/CSAT.js
@@ -1,0 +1,144 @@
+/**
+ * External dependencies.
+ */
+import { info } from '@wordpress/icons';
+
+/**
+ * WordPress dependencies.
+ */
+import {
+	Button,
+	Icon,
+	TextareaControl,
+	Tooltip
+} from '@wordpress/components';
+
+import { useSelect } from '@wordpress/data';
+
+import {
+	useEffect,
+	useState
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import CSAT from './csat/index';
+import useSettings from '../../utils/use-settings';
+
+const CSATList = () => {
+	const [ isVisible, setIsVisible ] = useState( false );
+	const [ getOption, updateOption, status ] = useSettings();
+
+	const settings = ( 'loaded' === status && undefined !== getOption( 'optml_csat' ) ) && JSON.parse( getOption( 'optml_csat' ) );
+
+	const {
+		hasImages,
+		isFirstSite
+	} = useSelect( select => {
+		const { getUserData } = select( 'optimole' );
+
+		return {
+			hasImages: 0 < getUserData()?.images_number,
+			isFirstSite: 1 === getUserData()?.app_count
+		};
+	});
+
+	const visits = localStorage.getItem( 'optimole_settings_visits' );
+
+	useEffect( () => {
+		setIsVisible( hasImages && isFirstSite && 3 <= parseInt( visits ) && false !== settings && true !== settings?.firstImpressions );
+	}, [ visits, settings ]);
+
+	return (
+		<>
+			<CSAT
+				id="first-impressions"
+				show={ isVisible }
+				onDismiss={ () => updateOption( 'optml_csat', JSON.stringify({ ...settings, firstImpressions: true }) ) }
+				strings={ {
+					title: optimoleDashboardApp.strings.csat.title,
+					close: optimoleDashboardApp.strings.csat.close
+				} }
+				pages={ [
+					{
+						showHeader: true,
+						content: ( props ) => (
+							<div className="flex flex-col gap-5 px-8 pb-8">
+								<div className="font-bold text-lg">
+									{ optimoleDashboardApp.strings.csat.heading_one }
+								</div>
+
+								<div className="flex gap-5">
+									{ [ 1, 2, 3, 4, 5 ].map( value => (
+										<Button
+											key={ value }
+											onClick={ () => props.changeData({ score: value }, true ) }
+											className="optml__button basis-full justify-center rounded font-bold min-h-40"
+										>
+											{ value }
+										</Button>
+									) ) }
+								</div>
+
+								<div className="flex justify-between">
+									<span className="text-purple-gray text-sm">{ optimoleDashboardApp.strings.csat.low }</span>
+									<span className="text-purple-gray text-sm">{ optimoleDashboardApp.strings.csat.high }</span>
+								</div>
+							</div>
+						)
+					},
+					{
+						showHeader: true,
+						content: ( props ) => (
+							<div className="flex flex-col gap-5 px-8 pb-8">
+								<div className="font-bold text-lg">
+									{ optimoleDashboardApp.strings.csat.heading_two }
+								</div>
+
+								<TextareaControl
+									label={ optimoleDashboardApp.strings.csat.heading_two }
+									hideLabelFromVision={ true }
+									value={ props.data?.feedback }
+									placeholder={ optimoleDashboardApp.strings.csat.feedback_placeholder }
+									onChange={ feedback => props.changeData({ feedback }) }
+								/>
+
+								<div className="flex justify-between">
+									<Tooltip
+										text={ optimoleDashboardApp.strings.csat.privacy_tooltip }
+									>
+										<div className="flex items-center cursor-pointer text-info">
+											<Icon icon={ info } className="mr-2 fill-info" />
+
+											{ optimoleDashboardApp.strings.csat.privacy }
+										</div>
+									</Tooltip>
+
+									<div className="flex gap-2">
+										<Button
+											onClick={ props.onSubmit }
+											className="optml__button basis-full justify-center rounded font-bold min-h-40"
+										>
+											{ optimoleDashboardApp.strings.csat.skip }
+										</Button>
+
+										<Button
+											variant="primary"
+											onClick={ props.onSubmit }
+											className="optml__button basis-full justify-center rounded font-bold min-h-40"
+										>
+											{ optimoleDashboardApp.strings.csat.submit }
+										</Button>
+									</div>
+								</div>
+							</div>
+						)
+					}
+				] }
+			/>
+		</>
+	);
+};
+
+export default CSATList;

--- a/assets/src/parts/connected/CSAT.js
+++ b/assets/src/parts/connected/CSAT.js
@@ -40,7 +40,7 @@ const CSATList = () => {
 
 		return {
 			hasImages: 0 < getUserData()?.images_number,
-			isFirstSite: 1 === getUserData()?.app_count
+			isFirstSite: 1 === getUserData()?.whitelist?.length
 		};
 	});
 
@@ -117,7 +117,7 @@ const CSATList = () => {
 
 									<div className="flex gap-2">
 										<Button
-											onClick={ props.onSubmit }
+											onClick={ () => props.onSubmit() }
 											className="optml__button basis-full justify-center rounded font-bold min-h-40"
 										>
 											{ optimoleDashboardApp.strings.csat.skip }
@@ -125,7 +125,7 @@ const CSATList = () => {
 
 										<Button
 											variant="primary"
-											onClick={ props.onSubmit }
+											onClick={ () => props.onSubmit() }
 											className="optml__button basis-full justify-center rounded font-bold min-h-40"
 										>
 											{ optimoleDashboardApp.strings.csat.submit }

--- a/assets/src/parts/connected/csat/index.js
+++ b/assets/src/parts/connected/csat/index.js
@@ -85,6 +85,8 @@ const CSAT = ({
 	}, [ hasSubmitted, data ]);
 
 	const onSubmit = ( dismiss = false, params = data ) => {
+		onDismiss();
+
 		if ( hasSubmitted || ! params?.score ) {
 			setHasDismissed( true );
 			return null;
@@ -117,7 +119,6 @@ const CSAT = ({
 		if ( dismiss ) {
 			setIsVisible( false );
 			setHasDismissed( true );
-			onDismiss();
 		}
 	};
 

--- a/assets/src/parts/connected/csat/index.js
+++ b/assets/src/parts/connected/csat/index.js
@@ -1,0 +1,176 @@
+/**
+ * External dependencies.
+ */
+import {
+	check,
+	closeSmall
+} from '@wordpress/icons';
+
+/**
+ * WordPress dependencies.
+ */
+import {
+	Button,
+	Icon
+} from '@wordpress/components';
+
+import {
+	useEffect,
+	useState
+} from '@wordpress/element';
+
+const Header = ({
+	strings,
+	onClose
+}) => {
+	return (
+		<div className="flex justify-between px-8 pt-8">
+			<p className="text-purple-gray text-sm m-0 py-2">
+				{ strings.title }
+			</p>
+
+			<Button
+				label={ strings.close }
+				icon={ closeSmall }
+				onClick={ onClose }
+				className="text-gray-950"
+			/>
+		</div>
+	);
+};
+
+const CSAT = ({
+	show = false,
+	strings = {},
+	pages = [],
+	onDismiss
+}) => {
+	const [ isVisibile, setIsVisible ] = useState( false );
+	const [ currentPage, setCurrentPage ] = useState( 0 );
+	const [ hasDismissed, setHasDismissed ] = useState( false );
+	const [ hasSubmitted, setHasSubmitted ] = useState( false );
+	const [ data, setData ] = useState({});
+
+	useEffect( () => {
+		if ( show && ! hasDismissed ) {
+			setIsVisible( show );
+		}
+	}, [ show ]);
+
+	const onSubmit = ( dismiss = true ) => {
+		if ( hasSubmitted || ! data?.score ) {
+			setHasDismissed( true );
+			return null;
+		}
+
+		const body = {
+			email: optimoleDashboardApp.user_data.user_email,
+			product: 'Optimole',
+			site: optimoleDashboardApp.home_url,
+			...data
+		};
+
+		try {
+			fetch( `https://api.themeisle.com/tracking/csat/${ score }`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Accept': 'application/json, */*;q=0.1',
+					'Cache-Control': 'no-cache'
+				},
+				body: JSON.stringify( body )
+			});
+		} catch ( e ) {
+			console.warn( e );
+		}
+
+		setHasSubmitted( true );
+		setCurrentPage( pages.length );
+		setIsVisible( false );
+		setHasDismissed( true );
+
+		if ( dismiss ) {
+			onDismiss();
+		}
+	};
+
+	const onClose = () => {
+		setIsVisible( false );
+		setHasDismissed( true );
+		onSubmit( false );
+		onDismiss();
+	};
+
+	if ( ! isVisibile ) {
+		return null;
+	}
+
+	if ( 0 === pages.length ) {
+		return null;
+	}
+
+	const changeData = ( obj, skip = false ) => {
+		setData({
+			...data,
+			...obj
+		});
+
+		if ( skip ) {
+			setCurrentPage( currentPage + 1 );
+		}
+	};
+
+	const canGoForward = currentPage < pages.length;
+
+	const Content = pages[ currentPage ]?.content;
+
+	return (
+		<div className="bg-white fixed right-0 bottom-0 m-12 gap-2 max-w-lg w-full flex flex-col text-gray-700 border-0 rounded-lg shadow-lg z-50">
+
+			{ pages[ currentPage ] && (
+				<>
+					{ pages[ currentPage ]?.showHeader && (
+						<Header
+							onClose={ onClose }
+							strings={ strings }
+						/>
+					) }
+
+					<Content
+						data={ data }
+						changeData={ changeData }
+						onSubmit={ onSubmit }
+					/>
+				</>
+			) }
+
+			{ ! canGoForward && (
+				<div className="flex flex-col gap-5 p-8 items-center">
+					<Icon
+						icon={ check }
+						size={ 40 }
+						className="bg-success rounded-full fill-white p-2"
+					/>
+
+					<div className="font-bold text-lg">
+						{ optimoleDashboardApp.strings.csat.heading_three }
+					</div>
+
+					<div className="text-sm text-center">
+						{ optimoleDashboardApp.strings.csat.thank_you }
+					</div>
+
+					<Button
+						variant="primary"
+						onClick={ () => setIsVisible( false ) }
+						className="optml__button basis-full justify-center rounded font-bold min-h-40"
+					>
+						{ optimoleDashboardApp.strings.csat.close }
+					</Button>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default CSAT;

--- a/assets/src/parts/connected/csat/index.js
+++ b/assets/src/parts/connected/csat/index.js
@@ -49,7 +49,7 @@ const CSAT = ({
 	show = false,
 	strings = {},
 	pages = [],
-	onDismiss
+	onDismiss = () => {}
 }) => {
 	const [ isVisibile, setIsVisible ] = useState( false );
 	const [ currentPage, setCurrentPage ] = useState( 0 );
@@ -84,7 +84,7 @@ const CSAT = ({
 		};
 	}, [ hasSubmitted, data ]);
 
-	const onSubmit = ( dismiss = true, params = data ) => {
+	const onSubmit = ( dismiss = false, params = data ) => {
 		if ( hasSubmitted || ! params?.score ) {
 			setHasDismissed( true );
 			return null;
@@ -113,10 +113,10 @@ const CSAT = ({
 
 		setHasSubmitted( true );
 		setCurrentPage( pages.length );
-		setIsVisible( false );
-		setHasDismissed( true );
 
 		if ( dismiss ) {
+			setIsVisible( false );
+			setHasDismissed( true );
 			onDismiss();
 		}
 	};
@@ -146,8 +146,7 @@ const CSAT = ({
 	const onClose = () => {
 		setIsVisible( false );
 		setHasDismissed( true );
-		onSubmit( false );
-		onDismiss();
+		onSubmit();
 	};
 
 	if ( ! isVisibile ) {
@@ -163,7 +162,7 @@ const CSAT = ({
 	const Content = pages[ currentPage ]?.content;
 
 	return (
-		<div className="bg-white fixed right-0 bottom-0 m-12 gap-2 max-w-lg w-full flex flex-col text-gray-700 border-0 rounded-lg shadow-lg z-50">
+		<div className="bg-white fixed left-0 w-auto sm:right-0 sm:left-auto sm:w-full bottom-0 m-12 gap-2 max-w-lg flex flex-col text-gray-700 border-0 rounded-lg shadow-lg z-50">
 
 			{ pages[ currentPage ] && (
 				<>

--- a/assets/src/parts/connected/index.js
+++ b/assets/src/parts/connected/index.js
@@ -19,6 +19,7 @@ import Conflicts from './conflicts';
 import Settings from './settings';
 import Help from './help';
 import Sidebar from './Sidebar';
+import CSAT from './CSAT';
 import { retrieveConflicts } from '../../utils/api';
 
 const ConnectedLayout = ({
@@ -85,26 +86,30 @@ const ConnectedLayout = ({
 	}, [ hasConflicts ]);
 
 	return (
-		<div className="optml-connected max-w-screen-xl flex flex-col lg:flex-row mx-auto gap-5">
-			<div
-				className="flex flex-col justify-between mt-8 mb-5 p-0 transition-all ease-in-out duration-700 relative text-gray-700 basis-9/12"
-			>
-				{ 'dashboard' === tab && <Dashboard /> }
+		<>
+			<div className="optml-connected max-w-screen-xl flex flex-col lg:flex-row mx-auto gap-5">
+				<div
+					className="flex flex-col justify-between mt-8 mb-5 p-0 transition-all ease-in-out duration-700 relative text-gray-700 basis-9/12"
+				>
+					{ 'dashboard' === tab && <Dashboard /> }
 
-				{ ( 'conflicts' === tab && showConflicts ) && <Conflicts /> }
+					{ ( 'conflicts' === tab && showConflicts ) && <Conflicts /> }
 
-				{ 'settings' === tab && (
-					<Settings
-						tab={ menu }
-						setTab={ setMenu }
-					/>
-				) }
+					{ 'settings' === tab && (
+						<Settings
+							tab={ menu }
+							setTab={ setMenu }
+						/>
+					) }
 
-				{ 'help' === tab && <Help /> }
+					{ 'help' === tab && <Help /> }
+				</div>
+
+				<Sidebar/>
 			</div>
 
-			<Sidebar/>
-		</div>
+			<CSAT />
+		</>
 	);
 };
 

--- a/assets/src/parts/connected/settings/index.js
+++ b/assets/src/parts/connected/settings/index.js
@@ -34,8 +34,7 @@ const Settings = ({
 		const {
 			getSiteSettings,
 			getQueryArgs,
-			isLoading,
-			extraVisits
+			isLoading
 		} = select( 'optimole' );
 
 		const siteSettings = getSiteSettings();
@@ -59,6 +58,16 @@ const Settings = ({
 			banner_frontend: extraVisits
 		});
 	}, [ extraVisits ]);
+
+	useEffect( () => {
+		const visits = localStorage.getItem( 'optimole_settings_visits' );
+
+		if ( 3 < visits ) {
+			return;
+		}
+
+		localStorage.setItem( 'optimole_settings_visits', visits ? parseInt( visits ) + 1 : 1 );
+	}, [ tab ]);
 
 	const loadSample = () => {
 		if ( ! showSample ) {

--- a/assets/src/utils/use-settings.js
+++ b/assets/src/utils/use-settings.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies.
+ */
+import api from '@wordpress/api';
+
+import { __ } from '@wordpress/i18n';
+
+import {
+	useEffect,
+	useState
+} from '@wordpress/element';
+
+/**
+ * useSettings Hook.
+ *
+ * useSettings hook to get/update WordPress' settings database.
+ *
+ * Setting field needs to be registered to REST for this function to work.
+ *
+ * @author  Hardeep Asrani <hardeepasrani@gmail.com>
+ * @version 1.0
+ *
+ */
+const useSettings = () => {
+	const [ settings, setSettings ] = useState({});
+	const [ status, setStatus ] = useState( 'loading' );
+
+	const getSettings = () => {
+		api.loadPromise.then( async() => {
+			try {
+				const settings = new api.models.Settings();
+				const response = await settings.fetch();
+				setSettings( response );
+			} catch ( error ) {
+				setStatus( 'error' );
+			} finally {
+				setStatus( 'loaded' );
+			}
+		});
+	};
+
+	useEffect( () => {
+		getSettings();
+	}, []);
+
+	const getOption = option => {
+		return settings?.[option];
+	};
+
+	const updateOption = ( option, value, success = __( 'Settings saved.', 'textdomain' ) ) => {
+		setStatus( 'saving' );
+
+		const save = new api.models.Settings({ [option]: value }).save();
+
+		save.success( ( response, status ) => {
+			if ( 'success' === status ) {
+				setStatus( 'loaded' );
+			}
+
+			if ( 'error' === status ) {
+				setStatus( 'error' );
+			}
+
+			getSettings();
+		});
+
+		save.error( ( response ) => {
+			setStatus( 'error' );
+		});
+	};
+
+	return [ getOption, updateOption, status ];
+};
+
+export default useSettings;

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1282,7 +1282,7 @@ The root cause might be either a security plugin which blocks this feature or so
 				'skip'                 => __( 'Skip', 'optimole-wp' ),
 				'submit'               => __( 'Submit', 'optimole-wp' ),
 				'privacy'              => __( 'What info we collect?', 'optimole-wp' ),
-				'privacy_tootip'       => __( 'We value privacy, that\'s why no IP addresses are collected after you submit the survey.', 'optimole-wp' ),
+				'privacy_tooltip'      => __( 'We value privacy, that\'s why no IP addresses are collected after you submit the survey.', 'optimole-wp' ),
 				'thank_you'            => __( 'Your input is highly appreciated and helps us shape a better experience in Optimole.', 'optimole-wp' ),
 			],
 		];

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1270,6 +1270,21 @@ The root cause might be either a security plugin which blocks this feature or so
 				'medium_optimization'   => __( '🤓 We are on the right track, <strong>{ratio}</strong> squeezed.', 'optimole-wp' ),
 				'big_optimization'      => __( '❤️❤️❤️ Our moles just nailed it, this one is <strong>{ratio}</strong> smaller.  ', 'optimole-wp' ),
 			],
+			'csat'                           => [
+				'title'                => __( 'Your opinion matters', 'optimole-wp' ),
+				'close'                => __( 'Close', 'optimole-wp' ),
+				'heading_one'          => __( 'How easy did you find to get started using Optimole, on a scale of 1 to 5?', 'optimole-wp' ),
+				'heading_two'          => __( 'Any specific feedback you would like to add?', 'optimole-wp' ),
+				'heading_three'        => __( 'Thank you!', 'optimole-wp' ),
+				'low'                  => __( 'Very Poor', 'optimole-wp' ),
+				'high'                 => __( 'Excellent', 'optimole-wp' ),
+				'feedback_placeholder' => __( 'Add your feedback here (optional)', 'optimole-wp' ),
+				'skip'                 => __( 'Skip', 'optimole-wp' ),
+				'submit'               => __( 'Submit', 'optimole-wp' ),
+				'privacy'              => __( 'What info we collect?', 'optimole-wp' ),
+				'privacy_tootip'       => __( 'We value privacy, that\'s why no IP addresses are collected after you submit the survey.', 'optimole-wp' ),
+				'thank_you'            => __( 'Your input is highly appreciated and helps us shape a better experience in Optimole.', 'optimole-wp' ),
+			],
 		];
 	}
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -161,7 +161,7 @@ class Optml_Settings {
 			}
 		}
 
-		add_action( 'init', array( $this, 'register_settings' ) );
+		add_action( 'init', [ $this, 'register_settings' ] );
 	}
 
 	/**
@@ -682,12 +682,12 @@ class Optml_Settings {
 		register_setting(
 			'optml_settings',
 			'optml_csat',
-			array(
+			[
 				'type'              => 'string',
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 				'default'           => '{}',
-			)
+			]
 		);
 	}
 }

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -160,6 +160,8 @@ class Optml_Settings {
 				}
 			}
 		}
+
+		add_action( 'init', array( $this, 'register_settings' ) );
 	}
 
 	/**
@@ -671,4 +673,21 @@ class Optml_Settings {
 		return get_option( $this->namespace, false );
 	}
 
+	/**
+	 * Get settings for CSAT.
+	 *
+	 * @return void
+	 */
+	public function register_settings() {
+		register_setting(
+			'optml_settings',
+			'optml_csat',
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+				'default'           => '{}',
+			)
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

<img width="2020" alt="Screenshot 2023-06-26 at 9 50 47 AM" src="https://github.com/Codeinwp/optimole-wp/assets/2649903/1d1624db-d8b0-448f-a39a-73aed660c75b">

This adds CSAT notice to Optimole Dashboard. The popup will be displayed when the following conditions are met:

- The user has completed the setup process (API connection).
- The user has visited any of the settings tabs three times.
- The user has optimized images.
- It is user's first website with Optimole, so if you connect the same account to another website, it shouldn't appear.
- Scores should be recorded regardless of whether the user leaves a comment.
- If you add a score leave the page (or refresh), the API request will be made when the page finishes reloading or the user comes back to the Optimole page.

Closes Codeinwp/optimole-service#893

### How to test the changes in this Pull Request:

1. Make sure all the conditions that are specified in the above section are met, and the CSAT popover appears only when the conditions are met.
2. Request is made properly and the CSAT doesn't appear when it's not supposed to appear, ie once it has been dismissed by the user or a request has been made already.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
