### PR TITLE
chore: removed native lazyload fallback

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -206,7 +206,10 @@ class Optml_Admin {
 			add_action( 'wp_before_admin_bar_render', [ $this, 'add_report_menu' ] );
 			add_action( 'wp_enqueue_scripts', [ $this, 'add_diagnosis_script' ] );
 		}
-		if ( ! $this->settings->use_lazyload() ) {
+		if ( ! $this->settings->use_lazyload()
+			|| ( $this->settings->get( 'native_lazyload' ) === 'enabled'
+				&& $this->settings->get( 'video_lazyload' ) === 'disabled'
+				&& $this->settings->get( 'bg_replacer' ) === 'disabled' ) ) {
 			return;
 		}
 		add_action( 'wp_enqueue_scripts', [ $this, 'frontend_scripts' ] );
@@ -302,19 +305,6 @@ class Optml_Admin {
 								maxHeight: %d,
 							}
 						}(window, document));
-					document.addEventListener( "DOMContentLoaded", function() {
-																		
-																		if ( "loading" in HTMLImageElement.prototype && Object.prototype.hasOwnProperty.call( optimoleData, "nativeLazyload" ) && optimoleData.nativeLazyload === true ) {
-																			const images = document.querySelectorAll(\'img[loading="lazy"]\');
-																					images.forEach( function (img) {
-																						if ( !img.dataset.optSrc) {
-																							return;
-																						}
-																						img.src = img.dataset.optSrc;
-																						delete img.dataset.optSrc;
-																					 });
-																		}
-																	} );
 		</script>',
 			Optml_Lazyload_Replacer::IFRAME_TEMP_COMMENT,
 			esc_url( $domain ),
@@ -1124,7 +1114,7 @@ The root cause might be either a security plugin which blocks this feature or so
 				'low_q_title'                       => __( 'Low', 'optimole-wp' ),
 				'medium_q_title'                    => __( 'Medium', 'optimole-wp' ),
 				'no_images_found'                   => __( 'You dont have any images in your Media Library. Add one and check how the Optimole will perform.', 'optimole-wp' ),
-				'native_desc'                       => __( 'Use browser native lazyload if supported, fallback to classic lazyload otherwise. When using browser native lazyload the auto scale feature is disabled', 'optimole-wp' ),
+				'native_desc'                       => __( 'Use browser native lazyload. When using browser native lazyload the auto scale feature is disabled', 'optimole-wp' ),
 				'option_saved'                      => __( 'Option saved.', 'optimole-wp' ),
 				'ml_quality_desc' => 'Optimole ML algorithms will predict the right quality for your image in order to get the smallest possible size with minimum perceived quality losses. Turning this off will allow you to control manually the quality.',
 				'quality_desc'                      => __( 'Lower image quality might not always be perceived by users and would result in a boost of your loading speed by lowering the page size. Try experimenting with the setting, then click the View sample image link to see what option works best for you.', 'optimole-wp' ),

--- a/inc/lazyload_replacer.php
+++ b/inc/lazyload_replacer.php
@@ -242,6 +242,14 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 		if ( ! $this->can_lazyload_for( $original_url, $full_tag ) ) {
 			return Optml_Tag_Replacer::instance()->regular_tag_replace( $new_tag, $original_url, $new_url, $optml_args, $is_slashed );
 		}
+
+		if ( self::instance()->settings->get( 'native_lazyload' ) === 'enabled' ) {
+			if ( strpos( $new_tag, 'loading=' ) === false ) {
+				$new_tag = preg_replace( '/<img/im', $is_slashed ? '<img loading=\"lazy\"' : '<img loading="lazy"', $new_tag );
+			}
+			return $new_tag;
+		}
+
 		$should_ignore_rescale = ! $this->is_valid_mimetype_from_url( $original_url, [ 'gif' => true, 'svg' => true ] );
 
 		if ( ! self::$is_lazyload_placeholder && ! $should_ignore_rescale ) {
@@ -296,9 +304,7 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 			1
 		);
 		$new_tag = str_replace( 'srcset=', 'old-srcset=', $new_tag );
-		if ( strpos( $new_tag, 'loading=' ) === false && self::instance()->settings->get( 'native_lazyload' ) === 'enabled' ) {
-			$new_tag = preg_replace( '/<img/im', $is_slashed ? '<img loading=\"lazy\"' : '<img loading="lazy"', $new_tag );
-		}
+
 		if ( ! $this->should_add_noscript( $new_tag ) ) {
 			return $new_tag;
 		}

--- a/tests/test-lazyload.php
+++ b/tests/test-lazyload.php
@@ -34,7 +34,7 @@ class Test_Lazyload extends WP_UnitTestCase {
 
 		] );
 		$settings->update( 'lazyload', 'enabled' );
-		$settings->update( 'native_lazyload', 'enabled' );
+		$settings->update( 'native_lazyload', 'disabled' );
 		$settings->update( 'video_lazyload', 'enabled' );
 		$settings->update( 'lazyload_placeholder', 'disabled' );
 		$settings->update( 'no_script', 'enabled' );
@@ -271,11 +271,12 @@ class Test_Lazyload extends WP_UnitTestCase {
 	}
 
 	public function test_width_100() {
+
 		$content = '<img height="100%" src="http://example.org/wp-content/uploads/2018/11/gradient.png" class="at0px" width="100%"/>';
 
 		$replaced_content = Optml_Manager::instance()->replace_content( $content );
 
-		$this->assertEquals( '<img decoding=async  loading="lazy" data-opt-src="https://test123.i.optimole.com/w:auto/h:auto/q:mauto/f:avif/http://example.org/wp-content/uploads/2018/11/gradient.png"  height="100%" src="https://test123.i.optimole.com/w:auto/h:auto/q:eco/f:avif/http://example.org/wp-content/uploads/2018/11/gradient.png" class="at0px" width="100%"/><noscript><img decoding=async  height="100%" src="https://test123.i.optimole.com/w:auto/h:auto/q:mauto/f:avif/http://example.org/wp-content/uploads/2018/11/gradient.png" class="at0px" width="100%"/></noscript>', $replaced_content );
+		$this->assertEquals( '<img decoding=async  data-opt-src="https://test123.i.optimole.com/w:auto/h:auto/q:mauto/f:avif/http://example.org/wp-content/uploads/2018/11/gradient.png"  height="100%" src="https://test123.i.optimole.com/w:auto/h:auto/q:eco/f:avif/http://example.org/wp-content/uploads/2018/11/gradient.png" class="at0px" width="100%"/><noscript><img decoding=async  height="100%" src="https://test123.i.optimole.com/w:auto/h:auto/q:mauto/f:avif/http://example.org/wp-content/uploads/2018/11/gradient.png" class="at0px" width="100%"/></noscript>', $replaced_content );
 
 	}
 	public function test_check_with_no_script() {
@@ -418,10 +419,14 @@ src="https://www.facebook.com/tr?id=472300923567306&ev=PageView&noscript=1" />
 	}
 
 	public function test_should_add_loading () {
+
+		$settings = new Optml_Settings();
+		$settings->update( 'native_lazyload', 'enabled' );
+		Optml_Manager::instance()->init();
+
 		$content          = '<img src="https://example.org/wp-content/uploads/2020/02/Herren.jpg" alt>';
 		$replaced_content = Optml_Manager::instance()->replace_content( $content );
 		$this->assertStringContainsString( 'i.optimole.com', $replaced_content );
-		$this->assertStringContainsString( 'data-opt-src', $replaced_content );
 		$this->assertStringContainsString( 'loading="lazy"', $replaced_content );
 	}
 
@@ -436,6 +441,11 @@ src="https://www.facebook.com/tr?id=472300923567306&ev=PageView&noscript=1" />
 	}
 
 	public function test_json_should_add_loading () {
+
+		$settings = new Optml_Settings();
+		$settings->update( 'native_lazyload', 'enabled' );
+		Optml_Manager::instance()->init();
+
 		$content          = [ '<img src="https://example.org/wp-content/uploads/2020/02/Herren.jpg" alt>',
 			'<img src="https://example.org/wp-content/uploads/2020/02/Herren.jpg" alt>',
 			'<img loading="lazy" src="https://example.org/wp-content/uploads/2020/02/Herren.jpg" alt>',
@@ -443,9 +453,8 @@ src="https://www.facebook.com/tr?id=472300923567306&ev=PageView&noscript=1" />
 		];
 		$replaced_content = Optml_Manager::instance()->replace_content( json_encode($content) );
 		$this->assertStringContainsString( 'i.optimole.com', $replaced_content );
-		$this->assertStringContainsString( 'data-opt-src', $replaced_content );
 		$this->assertStringContainsString( 'loading=\"eager\"', $replaced_content );
-		$this->assertEquals(4, substr_count( $replaced_content, 'loading=\"lazy\"' ));
+		$this->assertEquals(3, substr_count( $replaced_content, 'loading=\"lazy\"' ));
 	}
 
 	public function test_lazyload_iframe() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
Removes adding `data-opt-src` placeholder when native lazyload is enabled. 

Removes the redundant fallback script: https://vertis.d.pr/i/VCDGzP. 

When native lazyload is enabled and other lazyloads are disabled removes the lazyload script completely. 
 

Closes https://github.com/Codeinwp/optimole-service/issues/842 .

### How to test the changes in this Pull Request:

1. Install the pr plugin.
2. For any page and plugin setup this part of the lazyload script is removed https://vertis.d.pr/i/VCDGzP.
3. Check that when native lazyload is enabled `data-opt-src` is no longer added to image tags. 
4. Check that background lazyload still works with native lazyload enabled.
5. With native lazyload enabled, background lazyload and video lazyload disabled the js library is removed: https://vertis.d.pr/i/btGKzm .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
