### PR TITLE
fix: ensure service is connected before loading compatibilities

### DIFF
--- a/inc/compatibilities/compatibility.php
+++ b/inc/compatibilities/compatibility.php
@@ -14,6 +14,20 @@ abstract class Optml_compatibility {
 	 * @return bool Compatiblity
 	 */
 	abstract function should_load();
+
+	/**
+	 * Will the compatibility be loaded?
+	 *
+	 * @return bool
+	 */
+	public final function will_load() {
+		if ( ! Optml_Main::instance()->admin->settings->is_connected() ) {
+			return false;
+		}
+
+		return $this->should_load();
+	}
+
 	/**
 	 * Should we early load the compatibility?
 	 *

--- a/inc/compatibilities/elementor_builder.php
+++ b/inc/compatibilities/elementor_builder.php
@@ -15,7 +15,7 @@ class Optml_elementor_builder extends Optml_compatibility {
 	function should_load() {
 		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
-		return Optml_Main::instance()->admin->settings->is_connected() && is_plugin_active( 'elementor/elementor.php' );
+		return is_plugin_active( 'elementor/elementor.php' );
 	}
 
 	/**

--- a/inc/compatibilities/smart_search_woocommerce.php
+++ b/inc/compatibilities/smart_search_woocommerce.php
@@ -14,7 +14,7 @@ class Optml_smart_search_woocommerce extends Optml_compatibility {
 	 */
 	function should_load() {
 		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-		return Optml_Main::instance()->admin->settings->is_connected() && is_plugin_active( 'smart-search-for-woocommerce/woocommerce-searchanise.php' );
+		return is_plugin_active( 'smart-search-for-woocommerce/woocommerce-searchanise.php' );
 	}
 
 	/**

--- a/inc/compatibilities/yith_quick_view.php
+++ b/inc/compatibilities/yith_quick_view.php
@@ -15,7 +15,7 @@ class Optml_yith_quick_view extends Optml_compatibility {
 	function should_load() {
 		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
-		return  Optml_Main::instance()->admin->settings->is_connected() && is_plugin_active( 'yith-woocommerce-quick-view/init.php' );
+		return is_plugin_active( 'yith-woocommerce-quick-view/init.php' );
 	}
 
 	/**

--- a/inc/manager.php
+++ b/inc/manager.php
@@ -134,7 +134,7 @@ final class Optml_Manager {
 			 *
 			 * @var Optml_compatibility $compatibility Class to register.
 			 */
-			if ( $compatibility->should_load() ) {
+			if ( $compatibility->will_load() ) {
 				if ( $compatibility->should_load_early() ) {
 					$compatibility->register();
 					continue;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
The abstract compatibility class checks the service connection before evaluating other conditions in classes that inherit it.

Closes #579.

### How to test the changes in this Pull Request:
Unfortunately, we can't test with the plugin mentioned in the issue unless we have the pro version somewhere. One way to test this would be to see if compatibility with other plugins still loads.

We can check if the Elementor compatibility works fine. Similar testing to what we have in this PR should be acceptable because this removes the code that fixes that and solves it in a more abstract way: https://github.com/Codeinwp/optimole-wp/pull/574

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
