### PR TITLE
Add error notice when filter length is not 3 or more characters

### DIFF
--- a/assets/src/parts/connected/settings/FilterControl.js
+++ b/assets/src/parts/connected/settings/FilterControl.js
@@ -105,6 +105,7 @@ const FilterControl = ({
 	const [ filterOperator, setFilterOperator ] = useState( optimoleDashboardApp.strings.options_strings.filter_operator_contains );
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ filterMatchType, setFilterMatchType ] = useState( optimoleDashboardApp.strings.options_strings.filter_operator_contains );
+	const [ lengthError, setLengthError ] = useState( false );
 
 	const changeFilterType = value => {
 		let selectedValue = '';
@@ -122,12 +123,20 @@ const FilterControl = ({
 			setFilterOperator( optimoleDashboardApp.strings.options_strings.filter_operator_contains );
 		}
 
+		setLengthError( false );
 		setFilterValue( selectedValue );
 		setFilterType( value );
 	};
 
+	const updateFilterValue = value => {
+		setFilterValue( value );
+		setLengthError( false );
+	};
+
 	const addFilter = () => {
 		if ( 3 > filterValue.length ) {
+			setLengthError( true );
+
 			return;
 		}
 
@@ -255,7 +264,7 @@ const FilterControl = ({
 							<TextControl
 								value={ filterValue }
 								placeholder={ 'matches' === filterMatchType ? 'path' : 'word' }
-								onChange={ setFilterValue }
+								onChange={ updateFilterValue }
 								className="optml__input"
 							/>
 						) }
@@ -271,6 +280,9 @@ const FilterControl = ({
 						{ optimoleDashboardApp.strings.options_strings.add_filter }
 					</Button>
 				</div>
+				{ lengthError && (
+					<p className="text-red-500 bg-red-100 p-2 rounded-md border border-solid border-red-200">{ optimoleDashboardApp.strings.options_strings.filter_length_error }</p>
+				)}
 			</BaseControl>
 
 			{ hasItems && (

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1112,6 +1112,7 @@ The root cause might be either a security plugin which blocks this feature or so
 				'image_1_label'                     => __( 'Original', 'optimole-wp' ),
 				'image_2_label'                     => __( 'Optimized', 'optimole-wp' ),
 				'lazyload_desc'                     => __( 'We will generate images size based on your visitor\'s screen using javascript and render them without blocking the page execution via lazyload .', 'optimole-wp' ),
+				'filter_length_error'               => __( 'The filter should be at least 3 characters long.', 'optimole-wp' ),
 				'scale_desc'                        => __( 'When this option is off, we disable the automatic scaling of images on lazyload.', 'optimole-wp' ),
 				'low_q_title'                       => __( 'Low', 'optimole-wp' ),
 				'medium_q_title'                    => __( 'Medium', 'optimole-wp' ),


### PR DESCRIPTION


### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 - Adds a notice when the filter length is below three characters in the exclusions settings tab
 
![image](https://github.com/Codeinwp/optimole-wp/assets/15010186/825ff6e3-d13e-4b8e-8040-b779fac1928a)

Closes #530.

### How to test the changes in this Pull Request:

1. Go to settings, and try adding a filter with less than 3 characters;
2. An error should appear;
3. The error should be dismissed once you change anything in the filter control;

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
