### PR TITLE
Add Hero Image Preloader

### DIFF
--- a/inc/hero_preloader.php
+++ b/inc/hero_preloader.php
@@ -13,6 +13,13 @@
 class Optml_Hero_Preloader {
 
 	/**
+	 * Hold the settings object.
+	 *
+	 * @var Optml_Settings Settings object.
+	 */
+	public $settings;
+
+	/**
 	 * Cached object instance.
 	 *
 	 * @var Optml_Hero_Preloader
@@ -42,9 +49,12 @@ class Optml_Hero_Preloader {
 	 * @access public
 	 */
 	public static function instance() {
-		if ( null === self::$instance ) {
+		if ( null === self::$instance || ( self::$instance->settings !== null && ( ! self::$instance->settings->is_connected() ) ) ) {
 			self::$instance = new self();
-			self::$instance->init();
+			self::$instance->settings = new Optml_Settings();
+			if ( self::$instance->settings->is_connected() ) {
+				self::$instance->init();
+			}
 		}
 
 		return self::$instance;

--- a/inc/hero_preloader.php
+++ b/inc/hero_preloader.php
@@ -52,7 +52,7 @@ class Optml_Hero_Preloader {
 		if ( null === self::$instance || ( self::$instance->settings !== null && ( ! self::$instance->settings->is_connected() ) ) ) {
 			self::$instance = new self();
 			self::$instance->settings = new Optml_Settings();
-			if ( self::$instance->settings->is_connected() ) {
+			if ( self::$instance->settings->is_connected() && ! function_exists( 'wp_get_loading_optimization_attributes' ) ) {
 				self::$instance->init();
 			}
 		}

--- a/inc/hero_preloader.php
+++ b/inc/hero_preloader.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Optimole Hero Preloader.
+ *
+ * @package     Optimole/Inc
+ * @copyright   Copyright (c) 2023, Hardeep Asrani
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class Optml_Hero_Preloader
+ */
+class Optml_Hero_Preloader {
+
+	/**
+	 * Cached object instance.
+	 *
+	 * @var Optml_Hero_Preloader
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Has flagged preloading image.
+	 *
+	 * @var bool
+	 */
+	protected static $has_flagged_preloading_image = false;
+
+	/**
+	 * Has flagged preloading logo to prevent footer logos from being targetted.
+	 *
+	 * @var bool
+	 */
+	protected static $has_flagged_preloading_logo = false;
+
+	/**
+	 * Class instance method.
+	 *
+	 * @static
+	 * @return Optml_Hero_Preloader
+	 * @since  3.9.0
+	 * @access public
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+			self::$instance->init();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * The initialize method.
+	 *
+	 * @since  3.9.0
+	 * @access public
+	 */
+	public function init() {
+		add_filter( 'get_header_image_tag_attributes', [ $this, 'add_preload' ] );
+		add_filter( 'post_thumbnail_html', [ $this, 'add_preload_to_thumbnail' ] );
+		add_filter( 'wp_get_attachment_image_attributes', [ $this, 'add_preload_to_image_attributes' ], 10, 2 );
+		add_filter( 'get_custom_logo_image_attributes', [ $this, 'add_preload_to_logo' ] );
+		add_filter( 'wp_content_img_tag', [ $this, 'add_preload_to_thumbnail' ] );
+	}
+
+	/**
+	 * Add preload attribute to image.
+	 *
+	 * @since  3.9.0
+	 * @access public
+	 *
+	 * @param array $attr Image attributes.
+	 *
+	 * @return array
+	 */
+	public function add_preload( $attr ) {
+		if ( self::$has_flagged_preloading_image ) {
+			return $attr;
+		}
+
+		self::$has_flagged_preloading_image = true;
+
+		$attr['fetchpriority'] = 'high';
+		return $attr;
+	}
+
+	/**
+	 * Add preload attribute to thumbnail.
+	 *
+	 * @since  3.9.0
+	 * @access public
+	 *
+	 * @param string $html The post thumbnail HTML.
+	 *
+	 * @return string
+	 */
+	public function add_preload_to_thumbnail( $html ) {
+		if ( self::$has_flagged_preloading_image ) {
+			return $html;
+		}
+
+		if ( ! empty( $html ) && strpos( $html, 'loading="lazy"' ) === false && strpos( $html, 'fetchpriority=' ) === false ) {
+			self::$has_flagged_preloading_image = true;
+			$html = str_replace( '<img', '<img fetchpriority="high"', $html );
+		}
+		return $html;
+	}
+
+	/**
+	 * Filter attachment image attributes.
+	 *
+	 * @since  3.9.0
+	 * @access public
+	 *
+	 * @param array  $attr       Image attributes.
+	 * @param object $attachment Image attachment.
+	 *
+	 * @return array
+	 */
+	public function add_preload_to_image_attributes( $attr, $attachment ) {
+		if ( self::$has_flagged_preloading_image ) {
+			return $attr;
+		}
+
+		global $wp_query;
+
+		$post         = null;
+		$queried_post = get_queried_object();
+
+		if ( is_singular() && $queried_post instanceof WP_Post ) {
+			$post = $queried_post;
+		} elseif ( $wp_query->is_main_query() && isset( $wp_query->posts[0] ) ) {
+			$post = $wp_query->posts[0];
+		}
+
+		if ( $post instanceof WP_Post && $attachment instanceof WP_Post && (int) get_post_thumbnail_id( $post ) === $attachment->ID ) {
+			$attr = $this->add_preload( $attr );
+		}
+
+		return $attr;
+	}
+
+	/**
+	 * Add preload attribute to logo.
+	 *
+	 * @since  3.9.0
+	 * @access public
+	 *
+	 * @param array $attr Image attributes.
+	 *
+	 * @return array
+	 */
+	public function add_preload_to_logo( $attr ) {
+		if ( self::$has_flagged_preloading_logo ) {
+			return $attr;
+		}
+
+		self::$has_flagged_preloading_logo = true;
+
+		$attr['fetchpriority'] = 'high';
+		return $attr;
+	}
+}

--- a/inc/manager.php
+++ b/inc/manager.php
@@ -43,6 +43,16 @@ final class Optml_Manager {
 	 * @var Optml_Lazyload_Replacer Replacer instance.
 	 */
 	public $lazyload_replacer;
+
+	/**
+	 * Holds the hero preloader class.
+	 *
+	 * @access  public
+	 * @since   3.9.0
+	 * @var Optml_Hero_Preloader Preloader instance.
+	 */
+	public $hero_preloader;
+
 	/**
 	 * Holds plugin settings.
 	 *
@@ -108,6 +118,7 @@ final class Optml_Manager {
 			self::$instance->url_replacer      = Optml_Url_Replacer::instance();
 			self::$instance->tag_replacer      = Optml_Tag_Replacer::instance();
 			self::$instance->lazyload_replacer = Optml_Lazyload_Replacer::instance();
+			self::$instance->hero_preloader    = Optml_Hero_Preloader::instance();
 
 			add_action( 'after_setup_theme', [ self::$instance, 'init' ] );
 			add_action( 'wp_footer', [ self::$instance, 'banner' ] );

--- a/tests/test-preloading.php
+++ b/tests/test-preloading.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * WordPress unit test plugin.
+ *
+ * @package     Optimole-WP
+ * @subpackage  Tests
+ * @copyright   Copyright (c) 2023, Hardeep Asrani
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class Test_Preloading.
+ */
+class Test_Preloading extends WP_UnitTestCase {
+	public static $sample_attachement;
+
+	public function setUp() : void {
+		parent::setUp();
+		$settings = new Optml_Settings();
+		$settings->update( 'service_data', [
+			'cdn_key'    => 'test123',
+			'cdn_secret' => '12345',
+			'whitelist'  => [ 'example.com' ],
+
+		] );
+		$settings->update( 'lazyload', 'disabled' );
+		$settings->update( 'native_lazyload', 'disabled' );
+		$settings->update( 'video_lazyload', 'disabled' );
+		$settings->update( 'lazyload_placeholder', 'disabled' );
+		$settings->update( 'no_script', 'disabled' );
+		Optml_Url_Replacer::instance()->init();
+		Optml_Tag_Replacer::instance()->init();
+		Optml_Lazyload_Replacer::instance()->init();
+		Optml_Hero_Preloader::instance();
+		Optml_Manager::instance()->init();
+
+		self::$sample_attachement = self::factory()->attachment->create_upload_object( OPTML_PATH . 'assets/img/logo.png' );
+	}
+
+	public function test_preloading_header_image() {
+
+		$content = get_post( self::$sample_attachement );
+		$image   = wp_get_attachment_metadata( self::$sample_attachement );
+
+		$header_image_data = (object) array(
+			'attachment_id' => $content->ID,
+			'url'           => $content->guid,
+			'thumbnail_url' => $content->guid,
+			'height'        => $image['height'],
+			'width'         => $image['width'],
+		);
+
+		set_theme_mod( 'header_image', $header_image_data->url );
+		set_theme_mod( 'header_image_data', $header_image_data );
+
+		$header = get_header_image_tag();
+		$this->assertStringContainsString( 'fetchpriority="high"', $header );
+
+		// Test it doesn't add the attribute when called again.
+		$header = get_header_image_tag();
+		$this->assertStringNotContainsString( 'fetchpriority="high"', $header );
+	}
+
+	public function test_preloading_logo() {
+		set_theme_mod( 'custom_logo', self::$sample_attachement );
+		$logo = get_custom_logo();
+		$this->assertStringContainsString( 'fetchpriority="high"', $logo );
+
+		// Test it doesn't add the attribute when called again.
+		$logo = get_custom_logo();
+		$this->assertStringNotContainsString( 'fetchpriority="high"', $logo );
+	}
+}

--- a/tests/test-preloading.php
+++ b/tests/test-preloading.php
@@ -31,7 +31,7 @@ class Test_Preloading extends WP_UnitTestCase {
 		Optml_Url_Replacer::instance()->init();
 		Optml_Tag_Replacer::instance()->init();
 		Optml_Lazyload_Replacer::instance()->init();
-		Optml_Hero_Preloader::instance();
+		Optml_Hero_Preloader::instance()->init();
 		Optml_Manager::instance()->init();
 
 		self::$sample_attachement = self::factory()->attachment->create_upload_object( OPTML_PATH . 'assets/img/logo.png' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
This tries to detect Hero Images and adds `fetchpriority="high"` to them. It looks for the first image that matches the description and doesn't add it to any other images.

It also adds it to the first Site Logo if the theme is using WordPress' core logo function. Apart from that, for Hero Images it looks for:

- Page Header, if called using WP Core functions.
- Post Thumbnail, if called and used using WP Core functions.
- Image: If called using wp_get_attachment_image + it is the thumbnail of the post.
- Image in Post Content: If nothing is fount until the content, it uses the `wp_content_img_tag` to find the first image of the post and adds it to it. This also works with FSE themes.

I ran some tests with Neve & Neve FSE and here how the comparisons look, I'd recommend that we also try to test out a larger sample using maybe demosites staging.

<img width="1541" alt="2" src="https://github.com/Codeinwp/optimole-wp/assets/2649903/9e468b2e-e5ea-4ebb-bf9d-1cc9d88dfab6">
<img width="1540" alt="1" src="https://github.com/Codeinwp/optimole-wp/assets/2649903/1388111f-b67d-4c2f-a278-a3a1075d34bf">

<img width="1527" alt="Screenshot 2023-07-03 at 9 20 24 PM" src="https://github.com/Codeinwp/optimole-wp/assets/2649903/aeb7cdb9-9e10-4e96-ad85-0ea6cf560348">
<img width="1550" alt="Screenshot 2023-07-03 at 9 20 31 PM" src="https://github.com/Codeinwp/optimole-wp/assets/2649903/b02f2f13-c6b7-4156-b789-d49f219a7d9c">


Closes https://github.com/Codeinwp/optimole-service/issues/763.

### How to test the changes in this Pull Request:

1. Using https://www.webpagetest.org/webvitals, do test same websites with and without this version of the plugin. To prevent caching from meddling, better to have two websites with same data.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
