### PR TITLE
fix: Optimole banner appearing in the admin inside widget iframes

### DIFF
--- a/inc/manager.php
+++ b/inc/manager.php
@@ -156,6 +156,10 @@ final class Optml_Manager {
 	 * @return void
 	 */
 	public function banner() {
+		if ( defined( 'REST_REQUEST' ) ) {
+			return;
+		}
+
 		$has_banner = $this->settings->get( 'banner_frontend' ) === 'enabled';
 
 		if ( ! $has_banner ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
`wp_footer` hook is executed during the Rest API requests when rendering the widget iframes in the admin, so I've added a  check that we're not in a REST API request.

**LATER EDIT:** This seems to be a known issue, but it's been two years since it was opened: https://core.trac.wordpress.org/ticket/53801

Closes #590.

### How to test the changes in this Pull Request:

1. Activate the Optimole badge;
2. It should work as before on frontend;
3. It shouldn't be visible in the widgets screen in admin;
4. It shouldn't be visible in the widgets screen in the customizer;

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
