### PR TITLE
feat: add avif-ignore flag

### DIFF
--- a/inc/image.php
+++ b/inc/image.php
@@ -104,6 +104,10 @@ class Optml_Image extends Optml_Resource {
 			$path = '/sm:' . $params['strip_metadata'] . $path;
 		}
 
+		if ( isset( $params['ignore_avif'] ) && $params['ignore_avif'] === true ) {
+			$path = '/ig:avif' . $path;
+		}
+
 		if ( apply_filters( 'optml_keep_copyright', false ) === true ) {
 			$path = '/keep_copyright:true' . $path;
 		}

--- a/inc/url_replacer.php
+++ b/inc/url_replacer.php
@@ -279,6 +279,10 @@ final class Optml_Url_Replacer extends Optml_App_Replacer {
 			$arguments['strip_metadata'] = '0';
 		}
 
+		if ( $this->settings->get( 'avif' ) === 'disabled' ) {
+			$arguments['ignore_avif'] = true;
+		}
+
 		return  ( new Optml_Image( $url, $args, $this->active_cache_buster ) )->get_url( $arguments );
 
 	}

--- a/tests/test-replacer.php
+++ b/tests/test-replacer.php
@@ -279,6 +279,28 @@ class Test_Replacer extends WP_UnitTestCase {
 		$this->assertStringContainsString( '/h:150/', $replaced_content );
 	}
 
+	public function test_avif_disabled() {
+		$settings = new Optml_Settings();
+		$settings->update( 'avif', 'disabled' );
+		Optml_Url_Replacer::instance()->init();
+
+		$replaced_content = Optml_Manager::instance()->process_images_from_content( self::IMG_TAGS );
+		$this->assertStringContainsString( 'i.optimole.com', $replaced_content );
+		$this->assertStringContainsString( '/ig:avif/', $replaced_content );
+		$this->assertStringNotContainsString( '/f:avif/', $replaced_content );
+	}
+
+	public function test_avif_enabled() {
+		$settings = new Optml_Settings();
+		$settings->update( 'avif', 'enabled' );
+		Optml_Url_Replacer::instance()->init();
+
+		$replaced_content = Optml_Manager::instance()->process_images_from_content( self::IMG_TAGS );
+		$this->assertStringContainsString( 'i.optimole.com', $replaced_content );
+		$this->assertStringNotContainsString( '/ig:avif/', $replaced_content );
+		$this->assertStringContainsString( '/f:avif/', $replaced_content );
+	}
+
 	public function test_assets_url() {
 		$replaced_content = Optml_Manager::instance()->process_urls_from_content( self::ASSETS_URL );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
- Adds compatibility for the new AVIF flag in the URLs from this PR: https://github.com/Codeinwp/optimole-lambda-functions/pull/456
- Adds the `ig:avif` flag to images when the user disables the AVIF option in the plugin settings;
 
Closes Codeinwp/optimole-service#884.

### How to test the changes in this Pull Request:

1. Enable the plugin and add a image to a page that gets loaded as AVIF; You can check this in the inspector window under the Network tab under the Type of the resource:
![image](https://github.com/Codeinwp/optimole-wp/assets/15010186/d5e1024e-3643-45e7-bc4c-b412fcf7ff7c)
3. You can also check that the URL displayed on the page does not contain the `ig:avif` flag inside it;
4.  Disable the `Enable avif conversion` option inside the plugin settings, under **Advanced > Compression**;
5. You might need to clear the cached images from the **General > Clear cached resources** section in the settings;
6. Go back to the website and check that the image URL contains the `ig:avif` flag in it;
7. If you check the network tab, the image should not be AVIF anymore - it will probably be `jpeg` or `webp`;

You can use the following image to test this: [0.jpg.zip](https://github.com/Codeinwp/optimole-wp/files/12147195/0.jpg.zip)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
