### PR TITLE
feat: add option for generic lazy-loading placeholder color

### DIFF
--- a/assets/src/dashboard/parts/connected/settings/Lazyload.js
+++ b/assets/src/dashboard/parts/connected/settings/Lazyload.js
@@ -10,10 +10,16 @@ import {
 	__experimentalNumberControl as NumberControl,
 	BaseControl,
 	TextareaControl,
-	ToggleControl
+	ToggleControl,
+	ColorPicker,
+	ColorIndicator,
+	Button,
+	Popover
 } from '@wordpress/components';
 
 import { useSelect } from '@wordpress/data';
+
+import { useState } from '@wordpress/element';
 
 const Lazyload = ({
 	settings,
@@ -34,6 +40,9 @@ const Lazyload = ({
 	const isBGReplacerEnabled = 'disabled' !== settings[ 'bg_replacer' ];
 	const isVideoLazyloadEnabled = 'disabled' !== settings[ 'video_lazyload' ];
 	const isNoScriptEnabled = 'disabled' !== settings[ 'no_script' ];
+	const placeholderColor = settings[ 'placeholder_color' ];
+
+	const [ phPicker, setPhPicker ] = useState( false );
 
 	const updateOption = ( option, value ) => {
 		setCanSave( true );
@@ -49,20 +58,63 @@ const Lazyload = ({
 		setSettings( data );
 	};
 
+	const setColor = ( value ) => {
+		updateValue( 'placeholder_color', value );
+	};
+
 	return (
 		<>
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.enable_lazyload_placeholder_title }
-				help={ optimoleDashboardApp.strings.options_strings.enable_lazyload_placeholder_desc }
-				checked={ isLazyloadPlaceholderEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
-				) }
-				onChange={ value => updateOption( 'lazyload_placeholder', value ) }
-			/>
+			<BaseControl
+				help={<p dangerouslySetInnerHTML={{ __html: optimoleDashboardApp.strings.options_strings.enable_lazyload_placeholder_desc }}/>}>
+				<ToggleControl
+					label={ optimoleDashboardApp.strings.options_strings.enable_lazyload_placeholder_title }
+					checked={ isLazyloadPlaceholderEnabled }
+					disabled={ isLoading }
+					className={ classnames(
+						{
+							'is-disabled': isLoading
+						}
+					) }
+					onChange={ value => updateOption( 'lazyload_placeholder', value ) }
+				/>
+
+				{isLazyloadPlaceholderEnabled &&
+					<div className="relative inline-block">
+						<Button
+							disabled={isLoading}
+							className="gap-3 my-2 py-3 h-auto rounded text-inherit border-gray-400 border-2 border-solid font-medium"
+							onClick={() => {
+								setPhPicker( ! phPicker );
+							}}
+						>
+							<ColorIndicator colorValue={placeholderColor}/>
+							<span>{optimoleDashboardApp.strings.options_strings.lazyload_placeholder_color}</span>
+						</Button>
+
+						{phPicker &&
+						<Popover
+							placement="bottom"
+							position={'middle center'}
+							variant={'unstyled'}
+							className={'shadow-md border-grayish-blue border border-solid rounded bg-white p-2'}
+							onFocusOutside={() => setPhPicker( false )}
+						>
+							<ColorPicker
+								color={placeholderColor}
+								onChange={setColor}
+								enableAlpha
+								defaultValue=""
+							/>
+							<Button isDestructive={true}
+								className={'w-full text-center flex justify-center' }
+								variant={'secondary'} onClick={() => {
+									setColor( '' );
+								}}>{optimoleDashboardApp.strings.options_strings.clear}</Button>
+						</Popover>
+						}
+					</div>
+				}
+			</BaseControl>
 
 			<hr className="my-8 border-grayish-blue"/>
 

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1152,7 +1152,7 @@ The root cause might be either a security plugin which blocks this feature or so
 				'enable_cloud_images_title'         => __( 'Enable cloud library browsing', 'optimole-wp' ),
 				'enable_cloud_images_desc'          => sprintf( __( 'Grant permission for this site to access all images stored in your Optimole account. %1$s More details here%2$s', 'optimole-wp' ), '<a style="white-space: nowrap;" target=”_blank” href="https://docs.optimole.com/article/1323-cloud-library-browsing">', '<span style="font-size:15px; margin-top:2px;" class="dashicons dashicons-external"></span></a>' ),
 				'enable_image_replace'              => __( 'Enable image replacement', 'optimole-wp' ),
-				'enable_lazyload_placeholder_desc'  => __( 'Enabling this might affect the user experience in some cases, however it will reduce the number of total requests and page weight. Try it out and see how works best for you!', 'optimole-wp' ),
+				'enable_lazyload_placeholder_desc'  => __( 'Enabling this might affect the user experience in some cases, however it will reduce the number of total requests and page weight. Try it out and see how works best for you!', 'optimole-wp' ) . ' ' . sprintf( __( '%1$sMore details here%2$s.', 'optimole-wp' ), '<a target=”_blank” href="https://docs.optimole.com/article/1192-lazy-load-generic-placeholder">', '<span style="font-size:15px; margin-top:2px;" class="dashicons dashicons-external"></span></a>' ),
 				'enable_lazyload_placeholder_title' => __( 'Enable generic lazyload placeholder', 'optimole-wp' ),
 				'enable_network_opt_desc'           => __( 'Optimole provides an option to automatically downgrade the image quality when it detects a slower network.', 'optimole-wp' ),
 				'enable_network_opt_title'          => __( 'Enable network based optimizations', 'optimole-wp' ),
@@ -1271,7 +1271,8 @@ The root cause might be either a security plugin which blocks this feature or so
 				'select'                            => __( 'Please select one ...', 'optimole-wp' ),
 				'yes'                               => __( 'Restore images after disabling', 'optimole-wp' ),
 				'no'                                => __( 'Do not restore images after disabling', 'optimole-wp' ),
-
+				'lazyload_placeholder_color'        => __( 'Placeholder Color', 'optimole-wp' ),
+				'clear'                             => __( 'Clear', 'optimole-wp' ),
 			],
 			'help'                             => [
 				'section_one_title'           => __( 'Help and Support', 'optimole-wp' ),

--- a/inc/lazyload_replacer.php
+++ b/inc/lazyload_replacer.php
@@ -27,7 +27,7 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 
 	const IFRAME_TEMP_COMMENT = '/** optmliframelazyloadplaceholder */';
 
-	const SVG_PLACEHOLDER = 'data:image/svg+xml,%3Csvg%20viewBox%3D%220%200%20#width#%20#height#%22%20width%3D%22#width#%22%20height%3D%22#height#%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3C%2Fsvg%3E';
+	const SVG_PLACEHOLDER = 'data:image/svg+xml,%3Csvg%20viewBox%3D%220%200%20#width#%20#height#%22%20width%3D%22#width#%22%20height%3D%22#height#%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Crect%20width%3D%22#width#%22%20height%3D%22#height#%22%20fill%3D%22#fill#%22%2F%3E%3C%2Fsvg%3E';
 	/**
 	 * If frame lazyload is present on page.
 	 *
@@ -445,13 +445,19 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 
 		$width  = ! is_numeric( $width ) ? '100%' : $width;
 		$height = ! is_numeric( $height ) ? '100%' : $height;
+		$fill = $this->settings->get( 'placeholder_color' );
+
+		if ( empty( $fill ) ) {
+			$fill = 'transparent';
+		}
 
 		return
 			str_replace(
-				[ '#width#', '#height#' ],
+				[ '#width#', '#height#', '#fill#' ],
 				[
 					$width,
 					$height,
+					urlencode( $fill ),
 				],
 				self::SVG_PLACEHOLDER
 			);

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -95,6 +95,7 @@ class Optml_Settings {
 		'banner_frontend'      => 'disabled',
 		'offloading_status'    => 'disabled',
 		'rollback_status'      => 'disabled',
+		'placeholder_color'    => '',
 
 	];
 	/**
@@ -310,6 +311,7 @@ class Optml_Settings {
 					}
 					break;
 				case 'watchers':
+				case 'placeholder_color':
 					$sanitized_value = sanitize_text_field( $value );
 					break;
 				case 'skip_lazyload_images':
@@ -513,6 +515,7 @@ class Optml_Settings {
 			'banner_frontend'      => $this->get( 'banner_frontend' ),
 			'offloading_status'    => $this->get( 'offloading_status' ),
 			'rollback_status'      => $this->get( 'rollback_status' ),
+			'placeholder_color'   => $this->get( 'placeholder_color' ),
 		];
 	}
 

--- a/tests/test-lazyload.php
+++ b/tests/test-lazyload.php
@@ -458,7 +458,7 @@ src="https://www.facebook.com/tr?id=472300923567306&ev=PageView&noscript=1" />
 	}
 
 	public function test_lazyload_iframe() {
-		
+
 		$content = '<figure class="wp-block-embed-youtube wp-block-embed is-type-video is-provider-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio">
 					<div class="wp-block-embed__wrapper">
 					<iframe title="test" width="640" height="360" src="https://www.youtube.com/embed/-HwJNxE7hd8?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -508,7 +508,7 @@ src="https://www.facebook.com/tr?id=472300923567306&ev=PageView&noscript=1" />
 		$this->assertStringNotContainsString( 'data-opt-src', $replaced_content_skip );
 	}
 	public function test_lazyload_iframe_noscript_ignore() {
-		
+
 		$content = '<noscript><iframe width="930" height="523" src="http://5c128bbdd3b4.ngrok.io/" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 					</noscript>
 					<noscript><iframe width="930" height="523" src="http://5c128bbdd3b4.ngrok.io/" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
@@ -544,5 +544,28 @@ src="https://www.facebook.com/tr?id=472300923567306&ev=PageView&noscript=1" />
 		$this->assertStringNotContainsString( 'src="about:blank"', $replaced_content );
 		$this->assertStringNotContainsString( 'data-opt-src', $replaced_content );
 		$this->assertStringNotContainsString( '<noscript>', $replaced_content );
+	}
+
+	public function test_generic_placeholder() {
+		$settings = new Optml_Settings();
+
+		Optml_Manager::instance()->init();
+		$svg = Optml_Manager::instance()->lazyload_replacer->get_svg_for( 1200, 1300, 'http://example.org/testimage.png' );
+		$decoded = urldecode( $svg );
+
+		$this->assertStringContainsString( 'width="1200"', $decoded );
+		$this->assertStringContainsString( 'height="1300"', $decoded );
+		$this->assertStringContainsString( 'fill="transparent"', $decoded );
+
+
+		$settings->update( 'placeholder_color', '#bada55' );
+
+		Optml_Manager::instance()->init();
+		$svg = Optml_Manager::instance()->lazyload_replacer->get_svg_for( '', '', 'http://example.org/testimage.png' );
+		$decoded = urldecode( $svg );
+
+		$this->assertStringContainsString( 'width="100%"', $decoded );
+		$this->assertStringContainsString( 'height="100%"', $decoded );
+		$this->assertStringContainsString( 'fill="#bada55"', $decoded );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
- Adds setting for generic lazyload placeholder color; 
 
<details>
<summary>Screenshots</summary>

![image](https://github.com/Codeinwp/optimole-wp/assets/15010186/73307d37-c729-433c-82e6-097d63bd4da3)

![image](https://github.com/Codeinwp/optimole-wp/assets/15010186/13501ec0-7f2a-4e47-90fa-438d881bd3f6)

</details>

Closes #624.

### How to test the changes in this Pull Request:

1. Turn on **Enable generic lazyload placeholder** under **Settings > Lazyload**;
2. The button for the placeholder color should appear under the setting, allowing you to select a color;
3. This color will be empty by default - the placeholder being transparent;
4. Create a page containing images - you can also lower the **Exclude the first X images from lazyload** to **0** so all images on the page get lazyloaded (this is not going to work with DAM images as they are not lazyloaded yet);
5. You can enable network throttling under the browser inspector settings (Slow 3G) should be enough, so you have time to see the placeholders;
6. The placeholder for the lazyloaded images should have the color you select in the color picker;


<details>
<summary>How the placeholders should look:</summary>

![image](https://github.com/Codeinwp/optimole-wp/assets/15010186/732eb8a7-dd18-4222-81d4-ad80243b2f85)

</details>

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
