### PR TITLE
feat: add leave page confirmation if settings are updated [ref: #1034]

### DIFF
--- a/assets/src/dashboard/parts/connected/index.js
+++ b/assets/src/dashboard/parts/connected/index.js
@@ -26,30 +26,38 @@ const ConnectedLayout = ({
 	tab,
 	setTab
 }) => {
-	const [ showConflicts, setShowConflicts ] = useState( false );
-	const [ menu, setMenu ] = useState( 'general' );
-
 	const {
 		isConnected,
 		hasApplication,
-		hasConflicts
+		hasConflicts,
+		siteSettings,
+		extraVisits
 	} = useSelect( select => {
 		const {
 			isConnected,
 			hasApplication,
-			getConflicts
+			getConflicts,
+			getSiteSettings
 		} = select( 'optimole' );
 
 		const conflicts = getConflicts();
+		const siteSettings = getSiteSettings();
 
 		return {
 			isConnected: isConnected(),
 			hasApplication: hasApplication(),
-			hasConflicts: 0 < conflicts.count || 0
+			hasConflicts: 0 < conflicts.count || 0,
+			siteSettings,
+			extraVisits: siteSettings['banner_frontend']
 		};
 	});
 
 	const { setQueryArgs } = useDispatch( 'optimole' );
+
+	const [ showConflicts, setShowConflicts ] = useState( false );
+	const [ menu, setMenu ] = useState( 'general' );
+	const [ canSave, setCanSave ] = useState( false );
+	const [ settings, setSettings ] = useState( siteSettings );
 
 	useEffect( () => {
 		const urlSearchParams = new URLSearchParams( window.location.search );
@@ -85,6 +93,23 @@ const ConnectedLayout = ({
 		}
 	}, [ hasConflicts ]);
 
+	useEffect( () => {
+		setSettings({
+			...settings,
+			banner_frontend: extraVisits
+		});
+	}, [ extraVisits ]);
+
+	useEffect( () => {
+
+		// Confirmation message saying changes might not be saved if user leaves the page.
+		if ( canSave ) {
+			window.onbeforeunload = () => true;
+		} else {
+			window.onbeforeunload = null;
+		}
+	}, [ canSave ]);
+
 	return (
 		<>
 			<div className="optml-connected max-w-screen-xl flex flex-col lg:flex-row mx-auto gap-5">
@@ -99,6 +124,10 @@ const ConnectedLayout = ({
 						<Settings
 							tab={ menu }
 							setTab={ setMenu }
+							canSave={ canSave }
+							setCanSave={ setCanSave }
+							settings={ settings }
+							setSettings={ setSettings }
 						/>
 					) }
 

--- a/assets/src/dashboard/parts/connected/settings/index.js
+++ b/assets/src/dashboard/parts/connected/settings/index.js
@@ -25,12 +25,15 @@ import { toggleDamSidebarLink } from '../../../utils/helpers';
 
 const Settings = ({
 	tab,
-	setTab
+	setTab,
+	canSave,
+	setCanSave,
+	settings,
+	setSettings
 }) => {
 	const {
 		siteSettings,
 		isLoading,
-		extraVisits,
 		damEnabled
 	} = useSelect( select => {
 		const {
@@ -43,24 +46,14 @@ const Settings = ({
 
 		return {
 			siteSettings,
-			extraVisits: siteSettings['banner_frontend'],
 			damEnabled: siteSettings['cloud_images'],
 			isLoading: isLoading(),
 			queryArgs: getQueryArgs()
 		};
 	});
 
-	const [ settings, setSettings ] = useState( siteSettings );
-	const [ canSave, setCanSave ] = useState( false );
 	const [ showSample, setShowSample ] = useState( false );
 	const [ isSampleLoading, setIsSampleLoading ] = useState( false );
-
-	useEffect( () => {
-		setSettings({
-			...settings,
-			banner_frontend: extraVisits
-		});
-	}, [ extraVisits ]);
 
 	useEffect( () => {
 		toggleDamSidebarLink( 'enabled' === damEnabled );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
This adds a notice if you try to leave the page after changing settings you try to leave the page without saving your changes.

Closes https://github.com/Codeinwp/optimole-service/issues/1034.

### How to test the changes in this Pull Request:

1. Update few settings and confirm:
2. You see a notice when you try reloading the page if the changes aren't saved.
3. you shouldn't see that message if changes are saved.
4. Apart from that, saving of settings should work as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
