### PR TITLE
Feat/enrich image data

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -18,8 +18,7 @@ class Optml_Admin {
 
 	const IMAGE_DATA_COLLECTED = 'optml_image_data_collected';
 
-	// TODO: find the right batch size, keeping like this until finishing everything else for easier testing
-	const IMAGE_DATA_COLLECTED_BATCH = 5;
+	const IMAGE_DATA_COLLECTED_BATCH = 100;
 	/**
 	 * Hold the settings object.
 	 *
@@ -59,8 +58,8 @@ class Optml_Admin {
 			add_action( 'optml_pull_image_data_init', [$this, 'pull_image_data_init'] );
 			add_action( 'optml_pull_image_data', [$this, 'pull_image_data'] );
 			add_filter( 'wp_insert_attachment_data', [$this, 'detect_image_title_changes'], 10, 4 );
-			add_action( 'updated_post_meta', [$this, 'detect_image_alt_change' ], 10, 4);
-			add_action( 'added_post_meta', [$this,'detect_image_alt_change'], 10, 4 );
+			add_action( 'updated_post_meta', [$this, 'detect_image_alt_change' ], 10, 4 );
+			add_action( 'added_post_meta', [$this, 'detect_image_alt_change'], 10, 4 );
 			add_action( 'init', [ $this, 'schedule_data_enhance_cron' ] );
 		}
 		add_action( 'init', [ $this, 'update_default_settings' ] );
@@ -104,18 +103,26 @@ class Optml_Admin {
 			$image_url = wp_get_attachment_url( $attachment->ID );
 			$image_alt = get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true );
 			$image_title = $attachment->post_title;
+			$image_data[ $image_url ] = [];
 
-			$image_data[ $image_url ] = [
-				'alt' => $image_alt,
-				'title' => $image_title,
-			];
+			if ( ! empty( $image_alt ) ) {
+				$image_data[ $image_url ]['alt'] = $image_alt;
+			}
+			if ( ! empty( $image_title ) ) {
+				$image_data[ $image_url ]['title'] = $image_title;
+			}
+			if ( empty( $image_data[ $image_url ] ) ) {
+				unset( $image_data[ $image_url ] );
+			}
 
 			// Mark the image as processed
 			update_post_meta( $attachment->ID, self::IMAGE_DATA_COLLECTED, 'yes' );
 		}
 
-
-		do_action( 'optml_log', $image_data );
+		if ( ! empty( $image_data ) ) {
+			$api = new Optml_Api();
+			$api->call_data_enrich_api( $image_data );
+		}
 		if ( ! empty( $attachments ) ) {
 			wp_schedule_single_event( time() + 5, 'optml_pull_image_data' );
 		}
@@ -138,14 +145,14 @@ class Optml_Admin {
 	public function detect_image_title_changes( $data, $postarr, $unsanitized_postarr, $update ) {
 
 		// Check if it's an attachment being updated
-		if ($data['post_type'] !== 'attachment') {
+		if ( $data['post_type'] !== 'attachment' ) {
 			return $data;
 		}
-		if ( ! isset($postarr['ID'] ) ) {
+		if ( ! isset( $postarr['ID'] ) ) {
 			return $data;
 		}
-		if ( isset($postarr['post_title']) && isset($postarr['original_post_title']) && $postarr['post_title'] !== $postarr['original_post_title'] ) {
-			delete_post_meta($postarr['ID'], self::IMAGE_DATA_COLLECTED);
+		if ( isset( $postarr['post_title'] ) && isset( $postarr['original_post_title'] ) && $postarr['post_title'] !== $postarr['original_post_title'] ) {
+			delete_post_meta( $postarr['ID'], self::IMAGE_DATA_COLLECTED );
 		}
 
 		return $data;

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -74,12 +74,22 @@ class Optml_Admin {
 			add_filter( 'upload_mimes', [ $this, 'allow_meme_types' ] ); // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.upload_mimes
 		}
 	}
+	/**
+	 * Schedules the hourly cron that starts the querying for images alt/title attributes
+	 *
+	 * @uses action: init
+	 */
 	public function schedule_data_enhance_cron() {
 		if ( ! wp_next_scheduled( 'optml_pull_image_data_init' ) ) {
 			wp_schedule_event( time(), 'hourly', 'optml_pull_image_data_init' );
 		}
 	}
 
+	/**
+	 * Query the database for images and extract the alt/title to send them to the API
+	 *
+	 * @uses action: optml_pull_image_data
+	 */
 	public function pull_image_data() {
 		// Get all image attachments that are not processed
 		$args = [
@@ -128,12 +138,22 @@ class Optml_Admin {
 		}
 	}
 
+	/**
+	 * Schedule the event to pull image alt/title
+	 *
+	 * @uses action: optml_pull_image_data_init
+	 */
 	public function pull_image_data_init() {
 		if ( ! wp_next_scheduled( 'optml_pull_image_data' ) ) {
 			wp_schedule_single_event( time() + 5, 'optml_pull_image_data' );
 		}
 	}
 
+	/**
+	 * Delete the processed meta from an image when the alt text is changed
+	 *
+	 * @uses action: updated_post_meta, added_post_meta
+	 */
 	public function detect_image_alt_change( $meta_id, $post_id, $meta_key, $meta_value ) {
 
 		// Check if the updated metadata is for alt text and it's an attachment
@@ -141,7 +161,11 @@ class Optml_Admin {
 			delete_post_meta( $post_id, self::IMAGE_DATA_COLLECTED );
 		}
 	}
-
+	/**
+	 * Delete the processed meta from an image when the title is changed
+	 *
+	 * @uses filter: wp_insert_attachment_data
+	 */
 	public function detect_image_title_changes( $data, $postarr, $unsanitized_postarr, $update ) {
 
 		// Check if it's an attachment being updated

--- a/inc/api.php
+++ b/inc/api.php
@@ -314,6 +314,16 @@ final class Optml_Api {
 		return wp_remote_post( $this->onboard_api_root, $options );
 	}
 
+
+	/**
+	 * Send a list of images with alt/title values to update.
+	 *
+	 * @param array $images List of images.
+	 * @return array
+	 */
+	public function call_data_enrich_api( $images = [] ) {
+		return $this->request( 'optml/v2/media/add_data', 'POST', ['images' => $images, 'key' => Optml_Config::$key] );
+	}
 	/**
 	 * Register user remotely on optimole.com.
 	 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

Adds a cron that will run every hour which will start the process that pools the  alt/title for images and sends them to dashboard endpoint to be added to the cluster. 

The process will query a batch of 100 images at once and then schedule another action for the next batch. 

The images will be marked using the metadata to avoid redundant querying of the same image. 

Adds whatchers for when the alt/title are changed and deletes the metadata that marks the images as processed to allow the new alt/title values to be pooled and updated. 
 

Part of https://github.com/Codeinwp/optimole-service/issues/908 , needs https://github.com/Codeinwp/optimole-service/pull/1043 merged first. 

 This will not require testing as there is no frontend part where these are displayed for this part and the cluster will need to be queried to be able to check that the fields are added.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
