### PR TITLE
DAM images lazyload and URL parameters

### DIFF
--- a/inc/app_replacer.php
+++ b/inc/app_replacer.php
@@ -541,6 +541,10 @@ abstract class Optml_App_Replacer {
 			return false; // @codeCoverageIgnore
 		}
 
+		if ( $this->url_has_dam_flag( $url ) ) {
+			return true;
+		}
+
 		$url_parts = parse_url( $url );
 
 		if ( ! isset( $url_parts['host'] ) ) {
@@ -620,5 +624,16 @@ abstract class Optml_App_Replacer {
 		$optimized_url = ( new Optml_Image( $url, ['width' => $width, 'height' => $height, 'resize' => $resize, 'quality' => $this->settings->get_numeric_quality()], $this->settings->get( 'cache_buster' ) ) )->get_url();
 		$optimized_url = str_replace( $url, Optml_Media_Offload::KEYS['not_processed_flag'] . 'media_cloud' . '/' . Optml_Media_Offload::KEYS['uploaded_flag'] . $table_id . '/' . $url, $optimized_url );
 		return $optimized_url;
+	}
+
+	/**
+	 * Test that the url has the dam flag.
+	 *
+	 * @param string $url The image URL to check.
+	 *
+	 * @return bool
+	 */
+	public function url_has_dam_flag( $url ) {
+		return strpos( $url, Optml_Dam::URL_DAM_FLAG ) !== false;
 	}
 }

--- a/inc/dam.php
+++ b/inc/dam.php
@@ -30,6 +30,7 @@ class Optml_Dam {
 	private $dam_endpoint = 'https://dashboard.optimole.com/dam';
 
 	const OM_DAM_IMPORTED_FLAG = 'om-dam-imported';
+	const URL_DAM_FLAG = '/dam:1';
 
 	/**
 	 * Optml_Dam constructor.
@@ -60,6 +61,8 @@ class Optml_Dam {
 		add_filter( 'image_downsize', [ $this, 'catch_downsize' ], 10, 3 );
 		add_filter( 'wp_prepare_attachment_for_js', [$this, 'alter_attachment_for_js'], 10, 3 );
 		add_filter( 'wp_image_src_get_dimensions', [$this, 'alter_img_tag_w_h'], 10, 4 );
+		add_filter( 'get_attached_file', [$this, 'alter_attached_file_response'], 10, 2 );
+
 		add_filter(
 			'elementor/image_size/get_attachment_image_html',
 			[
@@ -208,6 +211,15 @@ class Optml_Dam {
 		// Use the original size if the requested size is full.
 		if ( $size === 'full' ) {
 			$metadata = wp_get_attachment_metadata( $attachment_id );
+
+			$image_url = $this->replace_dam_url_args(
+				[
+					'width'  => $metadata['width'],
+					'height' => $metadata['height'],
+					'crop'   => false,
+				],
+				$image_url
+			);
 
 			return [
 				$image_url,
@@ -363,6 +375,10 @@ class Optml_Dam {
 		if ( $is_svg ) {
 			$metadata['width']  = 150;
 			$metadata['height'] = 150;
+		}
+
+		if ( ! isset( $metadata['height'] ) || ! isset( $metadata['width'] ) ) {
+			return $metadata;
 		}
 
 		foreach ( $sizes as $size => $args ) {
@@ -774,6 +790,14 @@ class Optml_Dam {
 			);
 		}
 
+		$url_args = [
+			'height' => $response['height'],
+			'width'  => $response['width'],
+			'crop'   => false,
+		];
+
+		$response['url'] = $this->replace_dam_url_args( $url_args, $response['url'] );
+
 		return $response;
 	}
 
@@ -836,17 +860,25 @@ class Optml_Dam {
 	 * @return string
 	 */
 	public function replace_dam_url_args( $args, $subject ) {
-		$args = wp_parse_args( $args, [ 'width' => 'auto', 'height' => 'auto', 'crop' => false] );
+		$args = wp_parse_args( $args, [ 'width' => 'auto', 'height' => 'auto', 'crop' => false, 'dam' => true] );
 
 		$width = $args['width'];
 		$height = $args['height'];
 		$crop = (bool) $args['crop'];
 
-		$gravity = 'ce';
+		$gravity = Optml_Resize::GRAVITY_CENTER;
 
 		if ( $this->settings->get( 'resize_smart' ) === 'enabled' ) {
-			$gravity = 'sm';
+			$gravity = Optml_Resize::GRAVITY_SMART;
 		}
+
+        if( $width === 0 ) {
+            $width = 'auto';
+        }
+
+        if( $height === 0 ) {
+            $height = 'auto';
+        }
 
 		// Use the proper replacement for the image size.
 		$replacement = '/w:' . $width . '/h:' . $height;
@@ -857,6 +889,28 @@ class Optml_Dam {
 
 		$replacement .= '/q:';
 
+		if ( $args['dam'] ) {
+			$replacement = self::URL_DAM_FLAG . $replacement;
+		}
+
 		return preg_replace( '/\/w:(.*)\/h:(.*)\/q:/', $replacement, $subject );
+	}
+
+	/**
+	 * Elementor checks if the file exists before requesting a specific image size.
+	 *
+	 * Needed because otherwise there won't be any width/height on the `img` tags, breaking lazyload.
+	 *
+	 * @param string $file The file path.
+	 * @param int    $id The attachment ID.
+	 *
+	 * @return bool|string
+	 */
+	public function alter_attached_file_response( $file, $id ) {
+		if ( ! $this->is_dam_imported_image( $id ) ) {
+			return $file;
+		}
+
+		return true;
 	}
 }

--- a/inc/dam.php
+++ b/inc/dam.php
@@ -872,13 +872,13 @@ class Optml_Dam {
 			$gravity = Optml_Resize::GRAVITY_SMART;
 		}
 
-        if( $width === 0 ) {
-            $width = 'auto';
-        }
+		if ( $width === 0 ) {
+			$width = 'auto';
+		}
 
-        if( $height === 0 ) {
-            $height = 'auto';
-        }
+		if ( $height === 0 ) {
+			$height = 'auto';
+		}
 
 		// Use the proper replacement for the image size.
 		$replacement = '/w:' . $width . '/h:' . $height;

--- a/inc/image.php
+++ b/inc/image.php
@@ -40,7 +40,6 @@ class Optml_Image extends Optml_Resource {
 	private $resize = null;
 
 
-
 	/**
 	 * Optml_Image constructor.
 	 *
@@ -77,11 +76,86 @@ class Optml_Image extends Optml_Resource {
 	/**
 	 * Return transformed url.
 	 *
-	 * @param array $params Either will be signed or not.
+	 * @param array $params Image transforms parameters.
 	 *
 	 * @return string Transformed image url.
 	 */
 	public function get_url( $params = [] ) {
+		$path_params = $this->get_path_params( $params );
+
+		if ( $this->is_dam_url() ) {
+			return $this->get_dam_url( $path_params );
+		}
+
+		$path = $path_params . '/' . $this->source_url;
+
+		return sprintf( '%s%s', Optml_Config::$service_url, $path );
+
+	}
+
+	/**
+	 * Check if this contains the DAM flag.
+	 *
+	 * @return bool
+	 */
+	public function is_dam_url() {
+		return strpos( $this->source_url, Optml_Dam::URL_DAM_FLAG ) !== false;
+	}
+
+	/**
+	 * Get the DAM image URL.
+	 *
+	 * @param string $path_params Path parameters.
+	 *
+	 * @return string
+	 */
+	private function get_dam_url( $path_params ) {
+		$url = $this->source_url;
+
+		// Remove DAM flag.
+		$url = str_replace( Optml_Dam::URL_DAM_FLAG, '', $url );
+
+		// Split the path params.
+		$path_params_parts = explode( '/', $path_params );
+
+		foreach ( $path_params_parts as $param ) {
+			if ( empty( $param ) ) {
+				continue;
+			}
+
+			// Split into parts.
+			$param_parts = explode( ':', $param );
+
+			// Check if the param is width or height and if it's auto.
+			// Rely on the initial URL as it generates the correct image size.
+			if ( in_array( $param_parts[0], ['w', 'h'], true ) ) {
+				if ( $param_parts[1] === 'auto' ) {
+					continue;
+				}
+			}
+
+			// if the param exists we do a non-greedy replace for /$param:$value/ with the updated value.
+			if ( strpos( $url, '/' . $param_parts[0] . ':' ) !== false ) {
+				$url = preg_replace( '/\/' . $param_parts[0] . ':.*?\//', '/' . $param . '/', $url );
+
+				continue;
+			}
+
+			// Otherwise, we add it before the /q: param.
+			$url = str_replace( '/q:', '/' . $param . '/q:', $url );
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Get transform params as string.
+	 *
+	 * @param array $params Image transforms parameters.
+	 *
+	 * @return string Transform parameters string to use in the URL.
+	 */
+	private function get_path_params( $params = [] ) {
 		$path_parts = [];
 
 		$path_parts[] = $this->width->toString();
@@ -94,10 +168,11 @@ class Optml_Image extends Optml_Resource {
 		if ( isset( $params['apply_watermark'] ) && $params['apply_watermark'] && is_array( self::$watermark->get() ) && isset( self::$watermark->get()['id'] ) && self::$watermark->get()['id'] > 0 ) {
 			$path_parts[] = self::$watermark->toString();
 		}
-		$path = '/' . $this->source_url;
+
+		$path = '';
 
 		if ( isset( $params['format'] ) && ! empty( $params['format'] ) ) {
-			$path = '/f:' . $params['format'] . '/' . $this->source_url;
+			$path = '/f:' . $params['format'] . $path;
 		}
 
 		if ( isset( $params['strip_metadata'] ) && '0' === $params['strip_metadata'] ) {
@@ -119,7 +194,6 @@ class Optml_Image extends Optml_Resource {
 			$path = sprintf( '/%s%s', 'cb:' . $cache_buster, $path );
 		}
 
-		return sprintf( '%s%s', Optml_Config::$service_url, $path );
-
+		return $path;
 	}
 }

--- a/inc/manager.php
+++ b/inc/manager.php
@@ -643,7 +643,7 @@ final class Optml_Manager {
 		$extracted_urls  = array_filter(
 			$extracted_urls,
 			function ( $value ) use ( $slashed_config ) {
-				return strpos( $value, Optml_Config::$service_url ) === false && strpos( $value, $slashed_config ) === false || Optml_Media_Offload::is_not_processed_image( $value );
+				return strpos( $value, Optml_Config::$service_url ) === false && strpos( $value, $slashed_config ) === false || Optml_Media_Offload::is_not_processed_image( $value ) || $this->tag_replacer->url_has_dam_flag( $value );
 			}
 		);
 		$upload_resource = $this->tag_replacer->get_upload_resource();

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -718,6 +718,10 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 		}
 
 		foreach ( $image_ids as $id ) {
+			// Skip DAM attachment filtering.
+			if ( ! empty( get_post_meta( $id, Optml_Dam::OM_DAM_IMPORTED_FLAG, true ) ) ) {
+				continue;
+			}
 			$current_meta = wp_get_attachment_metadata( $id );
 			if ( ! isset( $current_meta['file'] ) || ! self::is_uploaded_image( $current_meta['file'] ) ) {
 				delete_post_meta( $id, 'optimole_offload' );
@@ -985,6 +989,12 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 		if ( ! isset( $meta['file'] ) ) {
 			return $url;
 		}
+
+		// Skip DAM attachment filtering.
+		if ( ! empty( get_post_meta( $attachment_id, Optml_Dam::OM_DAM_IMPORTED_FLAG, true ) ) ) {
+			return $url;
+		}
+
 		$file = $meta['file'];
 		if ( self::is_uploaded_image( $file ) ) {
 			$optimized_url = ( new Optml_Image( $url, ['width' => 'auto', 'height' => 'auto', 'quality' => $this->settings->get_numeric_quality()], $this->settings->get( 'cache_buster' ) ) )->get_url();

--- a/inc/tag_replacer.php
+++ b/inc/tag_replacer.php
@@ -162,7 +162,7 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 				$images['img_url'][ $index ] = $new_src;
 			}
 			if ( ( apply_filters( 'optml_ignore_image_link', false, $src ) ||
-				 false !== strpos( $src, Optml_Config::$service_url ) ||
+				 ( false !== strpos( $src, Optml_Config::$service_url ) && ! $this->url_has_dam_flag( $src ) ) ||
 				 ! $this->can_replace_url( $src ) ||
 				 ! $this->can_replace_tag( $images['img_url'][ $index ], $tag ) ) && ! Optml_Media_Offload::is_not_processed_image( $src )
 			) {

--- a/inc/url_replacer.php
+++ b/inc/url_replacer.php
@@ -152,7 +152,7 @@ final class Optml_Url_Replacer extends Optml_App_Replacer {
 				$url = $unoptimized_url;
 			}
 		}
-		if ( strpos( $url, Optml_Config::$service_url ) !== false ) {
+		if ( strpos( $url, Optml_Config::$service_url ) !== false && ! $this->url_has_dam_flag( $url ) ) {
 			return $original_url;
 		}
 

--- a/tests/test-dam.php
+++ b/tests/test-dam.php
@@ -180,11 +180,11 @@ class Test_Dam extends WP_UnitTestCase {
 	public function test_dam_size_gravity_replacer() {
 		$url_map = [
 			'https://cloudUrlTest.test/w:auto/h:auto/q:auto/id:testId/https://test-site.test/9.jpg' => [
-				'expected' => 'https://cloudUrlTest.test/w:150/h:100/q:auto/id:testId/https://test-site.test/9.jpg',
+				'expected' => 'https://cloudUrlTest.test/dam:1/w:150/h:100/q:auto/id:testId/https://test-site.test/9.jpg',
 				'args'     => [ 'width' => 150, 'height' => 100 ]
 			],
 			'https://cloudUrlTest.test/w:auto/h:auto/q:auto/id:testId/directUpload/9.jpg'           => [
-				'expected' => 'https://cloudUrlTest.test/w:365/h:1200/g:ce/rt:fill/q:auto/id:testId/directUpload/9.jpg',
+				'expected' => 'https://cloudUrlTest.test/dam:1/w:365/h:1200/g:ce/rt:fill/q:auto/id:testId/directUpload/9.jpg',
 				'args'     => [ 'width' => 365, 'height' => 1200, 'crop' => true ]
 			],
 		];
@@ -200,7 +200,7 @@ class Test_Dam extends WP_UnitTestCase {
 
 		$url       = 'https://cloudUrlTest.test/w:auto/h:auto/q:auto/id:testId/https://test-site.test/9.jpg';
 		$processed = $this->dam->replace_dam_url_args( [ 'width' => 150, 'height' => 100, 'crop' => true ], $url );
-		$this->assertEquals( 'https://cloudUrlTest.test/w:150/h:100/g:sm/rt:fill/q:auto/id:testId/https://test-site.test/9.jpg', $processed );
+		$this->assertEquals( 'https://cloudUrlTest.test/dam:1/w:150/h:100/g:sm/rt:fill/q:auto/id:testId/https://test-site.test/9.jpg', $processed );
 
 		$this->settings->update( 'resize_smart', 'disabled' );
 	}
@@ -261,6 +261,8 @@ class Test_Dam extends WP_UnitTestCase {
 	public function test_alter_attachment_for_js() {
 		$mock_response = [
 			'sizes' => [],
+			'width' => 1920,
+			'height' => 1080
 		];
 
 		foreach ( $this->inserted_ids as $id ) {

--- a/tests/test-lazyload.php
+++ b/tests/test-lazyload.php
@@ -24,6 +24,7 @@ class Test_Lazyload extends WP_UnitTestCase {
 	<img src="http://example.org/wp-content/plugins/optimole-wp/assets/img/logo4.svg">
 	<img src="http://example.org/wp-content/optimole-wp/assets/img/logo5.gif">
 	 ';
+	const DAM_IMG_TAG = '<img width="100" height="200" src="https://cloudUrlTest.test/dam:1/w:auto/h:auto/q:auto/id:b1b12ee03bf3945d9d9bb963ce79cd4f/https://test-site.test/9.jpg">';
 	public function setUp() : void {
 		parent::setUp();
 		$settings = new Optml_Settings();
@@ -567,5 +568,11 @@ src="https://www.facebook.com/tr?id=472300923567306&ev=PageView&noscript=1" />
 		$this->assertStringContainsString( 'width="100%"', $decoded );
 		$this->assertStringContainsString( 'height="100%"', $decoded );
 		$this->assertStringContainsString( 'fill="#bada55"', $decoded );
+	}
+
+	public function test_dam_lazyloading() {
+		$replaced_content = Optml_Manager::instance()->process_images_from_content( self::DAM_IMG_TAG );
+
+		$this->assertStringContainsString( 'data-opt-src="https://cloudUrlTest.test/w:100/h:200/rt:fill/g:ce/f:best/q:mauto/id:b1b12ee03bf3945d9d9bb963ce79cd4f/https://test-site.test/9.jpg"', $replaced_content );
 	}
 }

--- a/tests/test-replacer.php
+++ b/tests/test-replacer.php
@@ -116,6 +116,9 @@ class Test_Replacer extends WP_UnitTestCase {
 					<img src="https://www.codeinwp.org/wp-content/uploads/2018/05/brands.png">https://www.codeinwp.org/wp-content/uploads/2018/05/brands.png
 				</div>
 			</div>';
+	const DAM_LINKS = '
+		https://cloudUrlTest.test/dam:1/w:auto/h:auto/q:auto/id:b1b12ee03bf3945d9d9bb963ce79cd4f/https://test-site.test/9.jpg
+	';
 
 	public static $sample_post;
 	public static $sample_attachement;
@@ -815,5 +818,17 @@ class Test_Replacer extends WP_UnitTestCase {
 
 			$this->assertStringContainsString( $data['expected'], $replaced_content );
 		}
+	}
+
+	public function test_dam_flag_removal() {
+		$this->assertStringContainsString( 'dam:1', self::DAM_LINKS );
+		$this->assertStringNotContainsString('f:best', self::DAM_LINKS);
+		$this->assertStringNotContainsString('q:mauto', self::DAM_LINKS);
+
+		$replaced_content = Optml_Manager::instance()->replace_content( self::DAM_LINKS );
+
+		$this->assertStringNotContainsString('dam:1', $replaced_content);
+		$this->assertStringContainsString('f:best', $replaced_content);
+		$this->assertStringContainsString('q:mauto', $replaced_content);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
- Filters out the DAM images from processing in offload and rollback;
- Allows DAM-imported images through the replacers so they can be lazyloaded, and their URLs can be replaced;
- Updates the `Optml_Image` class to add another branch for building DAM image URLs;
- When inserting an image sourced from the DAM, we now insert a `/dam:1` URL path parameter so we can efficiently identify these URLs when replacing them;
- Ensures that the height/width of DAM images can't be 0 when using an image size;

**Note for code review:** I'm a bit weary of the fix I had to do for Elementor images to pick up the proper `img` tag width and height (i.e., [forcing the core to see that there's an attached file](https://github.com/Codeinwp/optimole-wp/pull/653/files#diff-f7384a8d30d9b4d82a4194865bb6a45296dc811cdf9a23e057c6cc450768b8ceR898-R915)). I think this might need a second opinion @Codeinwp/optimole. I think we can probably leave this out for now if you see any problems, as it's an edge case.

Closes #616.
Closes #617.

### How to test the changes in this Pull Request:

**Note: This will not work for images inserted into posts before this build because we didn't previously add the `/dam:1` path parameter.**

### URL path parameters (#616):

1. Insert images from the cloud library into a page/post - this should work properly for all image sizes and most contexts, including backgrounds;
2. We should test that links of these images get a proper width/height based on the image tag - if it has w/h data attributes, these should be reflected in the file URL;
3. When switching the quality of the delivered images in the Optimole settings (disabling the Machine Learning quality, and switching to a number quality, it should be reflected in the URL of all images - `q:<number>`;
4. Turning off the AVIF support in the settings should show up in these image URLs: `/ig:avif` should be in the URL;
5. Toggling off/on the best format should reflect in the image URLs - checking for the `/f:best` flag;
6. Offloading and rolling back should work as expected, and fully ignore these images for now;

---

### Lazy-loading (#617):

1. Insert images from the DAM on a page - both as backgrounds and as standalone images;
2. You might find it helpful to use browser inspector network throttling to detect that lazy-loading works fine;
3. You can also use spacers between the images so you can more easily detect when images are loaded in the network tab of the browser inspector;
4. Make sure lazy-loading is enabled - this should work with both the generic lazy-load placeholder and with the default lazy-loading settings;
5. You can also lower the threshold for the `Exclude the first X images from lazyload` to 0 so all images get lazyloaded on the page;
6. Check the page you created. Images should lazyload just like the ones that are initially sourced from the website;


### Other mentions:
- All the above should work fine for Elementor pages as well;

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
