### PR TITLE
feat: invalidate updated images [ref:#602]

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -469,6 +469,40 @@ final class Optml_Api {
 	}
 
 	/**
+	 * Create invalidation request.
+	 * 
+	 * @param array $urls The urls to invalidate.
+	 * 
+	 * @return array|WP_Error
+	 */
+	public function create_invalidation( $urls ) {
+		$settings = new Optml_Settings();
+		$service_data = $settings->get( 'service_data' );
+		$app_key = '';
+		$domains = [];
+
+		if ( isset( $service_data['cdn_key'] ) ) {
+			$app_key = $service_data['cdn_key'];
+		}
+
+		$domains[] = get_home_url();
+
+		if ( empty( $app_key ) ) {
+			return new WP_Error( 'no_app_key', __( 'No app key found.', 'optimole-wp' ) );
+		}
+
+		return $this->request(
+			'/optml/v1/cache/invalidate',
+			'POST',
+			[
+				'URLs' => $urls,
+				'application' => $app_key,
+				'domains' => $domains,
+			]
+		);
+	}
+
+	/**
 	 * Throw error on object clone
 	 *
 	 * The whole idea of the singleton design pattern is that there is a single


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
This PR tries to fix the issue when images are updated in WordPress, like updating the file directly, like plugins like Enable Replace Media or WP All Import.

We use make of a hash as it is best at detecting changes as far as I've tested, while just checking the meta information wasn't enough. Obviously, for that reason, it won't work for older images but only on new images.
 

Closes #602.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
 
