### PR TITLE
fix: remove CSAT tooltip [closes Codeinwp/optimole-service#1077]

### DIFF
--- a/assets/src/dashboard/parts/connected/CSAT.js
+++ b/assets/src/dashboard/parts/connected/CSAT.js
@@ -104,17 +104,7 @@ const CSATList = () => {
 									onChange={ feedback => props.changeData({ feedback }) }
 								/>
 
-								<div className="flex justify-between">
-									<Tooltip
-										text={ optimoleDashboardApp.strings.csat.privacy_tooltip }
-									>
-										<div className="flex items-center cursor-pointer text-info">
-											<Icon icon={ info } className="mr-2 fill-info" />
-
-											{ optimoleDashboardApp.strings.csat.privacy }
-										</div>
-									</Tooltip>
-
+								<div className="flex justify-end">
 									<div className="flex gap-2">
 										<Button
 											onClick={ () => props.onSubmit() }

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1482,8 +1482,6 @@ The root cause might be either a security plugin which blocks this feature or so
 				'feedback_placeholder' => __( 'Add your feedback here (optional)', 'optimole-wp' ),
 				'skip'                 => __( 'Skip', 'optimole-wp' ),
 				'submit'               => __( 'Submit', 'optimole-wp' ),
-				'privacy'              => __( 'What info we collect?', 'optimole-wp' ),
-				'privacy_tooltip'      => __( 'We value privacy, that\'s why no IP addresses are collected after you submit the survey.', 'optimole-wp' ),
 				'thank_you'            => __( 'Your input is highly appreciated and helps us shape a better experience in Optimole.', 'optimole-wp' ),
 			],
 		];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 - Removes CSAT tooltip.
 

Closes Codeinwp/optimole-service#1077.

### How to test the changes in this Pull Request:

Follow the steps described here to show the CSAT popup: https://github.com/Codeinwp/optimole-wp/pull/575#issue-1772970164

1. On the second page of the CSAT popup there should be no tooltip anymore, or the button that opened the tooltip;

### Other information:

![image](https://github.com/Codeinwp/optimole-wp/assets/15010186/3b94dff8-44fb-44b5-bd55-3855e18f754e)


* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* ~[ ] Have you written new tests for your changes, as applicable?~
* [x] Have you successfully ran tests with your changes locally?
 
