### PR TITLE
fix: remove scheduled crons during uninstall

### DIFF
--- a/inc/main.php
+++ b/inc/main.php
@@ -72,8 +72,8 @@ final class Optml_Main {
 	 * Optml_Main constructor.
 	 */
 	public function __construct() {
-
 		register_activation_hook( OPTML_BASEFILE, [ $this, 'activate' ] );
+		register_deactivation_hook( OPTML_BASEFILE, [ $this, 'deactivate' ] );
 	}
 
 	/**
@@ -212,6 +212,18 @@ final class Optml_Main {
 		}
 
 		set_transient( 'optml_fresh_install', true, MINUTE_IN_SECONDS );
+	}
+
+	/**
+	 * Deactivate routine actions.
+	 *
+	 * @access public
+	 * @since  3.11.0
+	 */
+	public function deactivate() {
+		// Clear registered cron events.
+		wp_clear_scheduled_hook( 'optml_daily_sync' );
+		wp_clear_scheduled_hook( 'optml_pull_image_data_init' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
This PR removes scheduled cron events during the uninstall to get rid of the stray jobs.

Closes #659.

### How to test the changes in this Pull Request:

1. First, install [WP Control](https://wordpress.org/plugins/wp-crontrol/)
2. To reproduce the issue, you can connect to Optimole and then deactivate the plugin, you will find (using WP Control) couple of stray cron jobs from Optimole named `optml_daily_sync` and `optml_pull_image_data_init`
3. After applying this PR, you can reproduce the last step and the cron jobs should not be visible anymore.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
