### PR TITLE
fix: Motion.page iFrame & builder compatibility

### DIFF
--- a/inc/manager.php
+++ b/inc/manager.php
@@ -295,6 +295,10 @@ final class Optml_Manager {
 			&& array_key_exists( 'builder_id', $_GET ) && ! empty( $_GET['builder_id'] ) ) {
 			return false; // @codeCoverageIgnore
 		}
+		// Motion.page iFrame & builder
+		if ( (array_key_exists( 'motionpage_iframe', $_GET ) && $_GET['motionpage_iframe'] == 'true') || (array_key_exists( 'page', $_GET ) && $_GET['page'] == 'motionpage') ) {  // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+			return false; // @codeCoverageIgnore
+		}
 		/**
 		 * Disable replacement on POST request and when user is logged in, but allows for sample image call widget in dashboard
 		 */


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
Compatibility layer for [Motion.page](https://motiob.page) builder
 
 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
 
