### PR TITLE
fix: redo progress bar for consistency

### DIFF
--- a/assets/src/dashboard/parts/components/ProgressBar.js
+++ b/assets/src/dashboard/parts/components/ProgressBar.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+
+const ProgressBar = ({
+	value,
+	max,
+	className,
+	...props
+}) => {
+	const progress = Math.floor( ( value / max ) * 100 );
+	const background = props.background || '#FFF';
+
+	return (
+		<div
+			className={ classnames(
+				'w-full h-2.5 border rounded-md border-solid bg-white border-light-gray',
+				className
+			) }
+			role="progressbar"
+			aria-valuemin="0"
+			aria-valuemax={ max }
+			aria-valuenow={ value }
+			style={{
+				background: 'linear-gradient(90deg, var( --optml-progress ) ' + progress + '%, ' + background + ' ' + progress + '%)'
+			}}
+			{ ...props }
+		/>
+	);
+};
+
+export default ProgressBar;

--- a/assets/src/dashboard/parts/connected/dashboard/LastImages.js
+++ b/assets/src/dashboard/parts/connected/dashboard/LastImages.js
@@ -21,6 +21,8 @@ import {
 	requestStatsUpdate
 } from '../../../utils/api';
 
+import ProgressBar from '../../components/ProgressBar';
+
 const isInitialLoading = 'yes' !== optimoleDashboardApp.connection_status;
 
 const Image = ({
@@ -139,7 +141,7 @@ const LastImages = () => {
 			{ ( isInitialLoading && ! isLoaded ) && (
 				<div className="flex items-center flex-col py-2">
 					<p className="font-semibold">{ optimoleDashboardApp.strings.latest_images.loading_latest_images }</p>
-					<progress max={ maxTime } value={ timer } />
+					<ProgressBar max={ maxTime } value={ timer } />
 				</div>
 			) }
 

--- a/assets/src/dashboard/parts/connected/dashboard/index.js
+++ b/assets/src/dashboard/parts/connected/dashboard/index.js
@@ -25,6 +25,8 @@ import {
 	warning
 } from '../../../utils/icons';
 
+import ProgressBar from '../../components/ProgressBar';
+
 import LastImages from './LastImages';
 
 const cardClasses = 'flex p-6 bg-light-blue border border-blue-300 rounded-md';
@@ -163,7 +165,7 @@ const Dashboard = () => {
 					</div>
 
 					<div>
-						<progress
+						<ProgressBar
 							className="mt-2.5 mb-3 mx-0"
 							value={ userData.visitors }
 							max={ userData.visitors_limit }

--- a/assets/src/dashboard/parts/connected/settings/Compression.js
+++ b/assets/src/dashboard/parts/connected/settings/Compression.js
@@ -25,6 +25,8 @@ import { useSelect } from '@wordpress/data';
  */
 import { sampleRate } from '../../../utils/api';
 
+import ProgressBar from '../../components/ProgressBar';
+
 const Compression = ({
 	settings,
 	setSettings,
@@ -270,7 +272,7 @@ const Compression = ({
 												<p className="text-base">{ optimoleDashboardApp.strings.latest_images.same_size }</p>
 											) }
 
-											<progress
+											<ProgressBar
 												max={ 100 }
 												value={ getCompressionRatio() }
 											/>

--- a/assets/src/dashboard/parts/connected/settings/OffloadMedia.js
+++ b/assets/src/dashboard/parts/connected/settings/OffloadMedia.js
@@ -37,6 +37,8 @@ import {
 	saveSettings
 } from '../../../utils/api';
 
+import ProgressBar from '../../components/ProgressBar';
+
 const maxTime = 100;
 
 const OffloadMedia = ({
@@ -357,7 +359,7 @@ const OffloadMedia = ({
 								<Icon icon={ rotateRight } className="animate-spin fill-dark-blue" />
 							</div>
 
-							<progress
+							<ProgressBar
 								className="mt-2.5 mb-1.5 mx-0"
 								value={ Math.round( ( processedImages / totalNumberOfImages ) * 100 ) }
 								max={ maxTime }
@@ -441,7 +443,7 @@ const OffloadMedia = ({
 								<Icon icon={ rotateRight } className="animate-spin fill-dark-blue" />
 							</div>
 
-							<progress
+							<ProgressBar
 								className="mt-2.5 mb-1.5 mx-0"
 								value={ Math.round( ( processedImages / totalNumberOfImages ) * 100 ) }
 								max={ maxTime }

--- a/assets/src/dashboard/parts/connecting/index.js
+++ b/assets/src/dashboard/parts/connecting/index.js
@@ -8,6 +8,11 @@ import {
 	useState
 } from '@wordpress/element';
 
+/**
+ * Internal dependencies.
+ */
+import ProgressBar from '../components/ProgressBar';
+
 const progressMessages = [
 	optimoleDashboardApp.strings.options_strings.connect_step_0,
 	optimoleDashboardApp.strings.options_strings.connect_step_1,
@@ -58,10 +63,11 @@ const ConnectingLayout = () => {
 					<div className="font-bold text-2xl">{ optimoleDashboardApp.strings.account_connecting_title }</div>
 					<div className="text-base">{ optimoleDashboardApp.strings.account_connecting_subtitle }</div>
 
-					<progress
-						className="mt-2.5 mb-1.5 mx-0"
+					<ProgressBar
+						className="mt-2.5 mb-1.5 mx-0 h-5 border-gray-200"
 						value={ timer }
 						max={ maxTime }
+						background="#e6e6e6"
 					/>
 
 					<div className="text-xs">{ progressMessages[step] + ' ' + '(' + progress + '%)' }</div>

--- a/assets/src/dashboard/style.scss
+++ b/assets/src/dashboard/style.scss
@@ -25,6 +25,7 @@ $disabled: #6786F4;
 #optimole-app {
 	--wp-admin-theme-color: #577BF9;
 	--wp-components-color-foreground: #577BF9;
+	--optml-progress: #577BF9;
 
 	a {
 		text-decoration: none;
@@ -82,7 +83,7 @@ $disabled: #6786F4;
 
 	.optml-connect {
 		.dashicon {
-			color: #577BF9;
+			color: $info;
 		}
 	}
 
@@ -90,37 +91,7 @@ $disabled: #6786F4;
 		font-size: 13px;
 	}
 
-	progress[value] {
-		appearance: none;
-		height: 20px;
-		border-radius: 6px;
-		width: 100%;
-	}
-
-	progress {
-		&::-webkit-progress-value,
-		&::-webkit-progress-bar,
-		&::-moz-progress-bar {
-			background: $info;
-		}
-	}
-
 	.optml-connected {
-		progress {
-			&::-webkit-progress-value,
-			&::-webkit-progress-bar,
-			&::-moz-progress-bar {
-				background: $info;
-			}
-		}
-
-		progress[value] {
-			background: white;
-			appearance: none;
-			height: 10px;
-			border: 1px solid rgba(87, 123, 249, 0.36);
-		}
-
 		.components-toggle-control {
 			.components-base-control__field > .components-flex {
 				flex-direction: row-reverse;
@@ -171,7 +142,7 @@ $disabled: #6786F4;
 
 				.components-dropdown-menu__menu {
 					.components-button:hover {
-						color: #577BF9;
+						color: $info;
 					}
 					.components-button:last-child:hover {
 						color: #EF686B;
@@ -283,8 +254,8 @@ $disabled: #6786F4;
 	}
 
 	&__button {
-		color: #577BF9;
-		border: 2px solid #577BF9;
+		color: $info;
+		border: 2px solid $info;
 
 		&:focus:not(:disabled) {
 			border: none;
@@ -375,7 +346,7 @@ $disabled: #6786F4;
 			display: inline-flex;
 			justify-content: center;
 			color: white;
-			background: #577BF9;
+			background: $info;
 			padding: 4px 8px;
 			border-radius: 6px;
 
@@ -385,7 +356,7 @@ $disabled: #6786F4;
 				top: -38%;
 				border-width: 5px;
 				border-style: solid;
-				border-color: transparent transparent #577BF9 transparent;
+				border-color: transparent transparent $info transparent;
 			}
 		}
 	}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
 	content: [
-		'./assets/src/**/*.js',
+		'./assets/src/**/*.js'
 	],
 	theme: {
 		extend: {
@@ -21,7 +21,8 @@ module.exports = {
 				'light-black': '#626262',
 				'opaque-black': '#0000006E',
 				'stale-yellow': '#FFF0C9',
-				'disabled': '#6786F4'
+				'disabled': '#6786F4',
+				'light-gray': 'rgba(87, 123, 249, 0.36)'
 			},
 			fontFamily: {
 				'serif': [ '-apple-system', 'BlinkMacSystemFont', 'sans-serif' ]
@@ -37,6 +38,6 @@ module.exports = {
 			minHeight: {
 				'40': '40px'
 			}
-		},
-	},
-}
+		}
+	}
+};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
This PR replaces the native Progress Bar usage with a new ProgressBar component that looks similar in all browsers.
 
It appears in 5 locations:

- Loading during the first connect
- Images loading after first connect
- Main Dashboard image usage
- In "Enable Auto Quality powered by ML(Machine Learning)" setting's View Sample
- In Offloading/Rollback loading

Closes #660.

### How to test the changes in this Pull Request:

1. Make sure the ProgressBar is the same as before and looks the same in all browsers.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
