### PR TITLE
feat: remove Resize large images original source

### DIFF
--- a/assets/src/dashboard/parts/connected/settings/Resize.js
+++ b/assets/src/dashboard/parts/connected/settings/Resize.js
@@ -239,37 +239,6 @@ const Resize = ({
 					) ) }
 				</BaseControl>
 			) }
-
-			<hr className="my-8 border-grayish-blue"/>
-
-			<BaseControl
-				label={ optimoleDashboardApp.strings.options_strings.size_title }
-				help={ optimoleDashboardApp.strings.options_strings.size_desc }
-			>
-				<div className="flex gap-8">
-					<NumberControl
-						label={ optimoleDashboardApp.strings.options_strings.width_field }
-						labelPosition="side"
-						value={ settings[ 'max_width' ] }
-						type="number"
-						min={ 100 }
-						max={ 10000 }
-						className="basis-1/2 sm:basis-1/4"
-						onChange={ value => updateValue( 'max_width', value ) }
-					/>
-
-					<NumberControl
-						label={ optimoleDashboardApp.strings.options_strings.height_field }
-						labelPosition="side"
-						value={ settings[ 'max_height' ] }
-						type="number"
-						min={ 100 }
-						max={ 10000 }
-						className="basis-1/2 sm:basis-1/4"
-						onChange={ value => updateValue( 'max_height', value ) }
-					/>
-				</div>
-			</BaseControl>
 		</>
 	);
 };

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -34,6 +34,7 @@ class Optml_Admin {
 	public $conflicting_plugins;
 
 	const NEW_USER_DEFAULTS_UPDATED = 'optml_defaults_updated';
+	const OLD_USER_ENABLED_LD = 'optml_enabled_limit_dimensions';
 
 	/**
 	 * Optml_Admin constructor.
@@ -63,6 +64,7 @@ class Optml_Admin {
 			add_action( 'init', [ $this, 'schedule_data_enhance_cron' ] );
 		}
 		add_action( 'init', [ $this, 'update_default_settings' ] );
+		add_action( 'init', [ $this, 'update_limit_dimensions' ] );
 		add_action( 'admin_init', [ $this, 'maybe_redirect' ] );
 		add_action( 'admin_init', [ $this, 'init_no_script' ] );
 		if ( ! is_admin() && $this->settings->is_connected() && ! wp_next_scheduled( 'optml_daily_sync' ) ) {
@@ -223,6 +225,25 @@ class Optml_Admin {
 		$this->settings->update( 'lazyload', 'enabled' );
 
 		update_option( self::NEW_USER_DEFAULTS_UPDATED, 'yes' );
+	}
+	/**
+	 * Enable limit dimensions for old users after removing the Resize option.
+	 *
+	 * @return void
+	 */
+	public function update_limit_dimensions() {
+		if ( get_option( self::OLD_USER_ENABLED_LD ) === 'yes' ) {
+			return;
+		}
+
+		// New users already have this enabled as we changed defaults.
+		if ( ! $this->settings->is_connected() ) {
+			return;
+		}
+
+		$this->settings->update( 'limit_dimensions', 'enabled' );
+
+		update_option( self::OLD_USER_ENABLED_LD, 'yes' );
 	}
 	/**
 	 * Adds Optimole tag to admin bar
@@ -1339,8 +1360,6 @@ The root cause might be either a security plugin which blocks this feature or so
 				'selected_sites_desc'               => __( 'Site: ', 'optimole-wp' ),
 				'selected_all_sites_desc'           => __( 'Currently viewing images from all sites ', 'optimole-wp' ),
 				'select_all_sites_desc'             => __( 'View images from all sites ', 'optimole-wp' ),
-				'size_desc'                         => __( 'We resize all images with sizes greater than the values defined here. Changing this option is not recommended unless large images are not being processed correctly. This does NOT affect the scaling of images on the frontend.', 'optimole-wp' ),
-				'size_title'                        => __( 'Resize large images original source.', 'optimole-wp' ),
 				'select_site'                       => __( 'Select a website', 'optimole-wp' ),
 				'cloud_site_title'                  => __( 'Show images only from these sites: ', 'optimole-wp' ),
 				'cloud_site_desc'                   => __( 'Only the images from the selected sites will be displayed on this site. Defaults to all.', 'optimole-wp' ),

--- a/inc/app_replacer.php
+++ b/inc/app_replacer.php
@@ -57,18 +57,6 @@ abstract class Optml_App_Replacer {
 	 */
 	public $settings = null;
 	/**
-	 * Defines which is the maximum width accepted in the optimization process.
-	 *
-	 * @var int
-	 */
-	protected $max_width = 3000;
-	/**
-	 * Defines which is the maximum width accepted in the optimization process.
-	 *
-	 * @var int
-	 */
-	protected $max_height = 3000;
-	/**
 	 * Defines if the dimensions should be limited when images are served.
 	 *
 	 * @var bool
@@ -440,9 +428,6 @@ abstract class Optml_App_Replacer {
 		$this->allowed_sources['i1.wp.com'] = true;
 		$this->allowed_sources['i2.wp.com'] = true;
 		$this->is_allowed_site              = count( array_diff_key( $this->possible_sources, $this->allowed_sources ) ) > 0;
-
-		$this->max_height = $this->settings->get( 'max_height' );
-		$this->max_width  = $this->settings->get( 'max_width' );
 
 		$this->limit_dimensions_enabled = $this->settings->get( 'limit_dimensions' ) === 'enabled';
 		if ( $this->limit_dimensions_enabled ) {

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -54,8 +54,6 @@ class Optml_Settings {
 		'cache_buster_assets'  => '',
 		'cache_buster_images'  => '',
 		'cdn'                  => 'disabled',
-		'max_height'           => 1500,
-		'max_width'            => 2000,
 		'admin_bar_item'       => 'enabled',
 		'lazyload'             => 'disabled',
 		'scale'                => 'disabled',
@@ -64,7 +62,7 @@ class Optml_Settings {
 		'bg_replacer'          => 'enabled',
 		'video_lazyload'       => 'enabled',
 		'retina_images'        => 'disabled',
-		'limit_dimensions'     => 'disabled',
+		'limit_dimensions'     => 'enabled',
 		'limit_height'         => 1080,
 		'limit_width'          => 1920,
 		'resize_smart'         => 'disabled',
@@ -262,8 +260,6 @@ class Optml_Settings {
 				case 'best_format':
 					$sanitized_value = $this->to_map_values( $value, [ 'enabled', 'disabled' ], 'enabled' );
 					break;
-				case 'max_width':
-				case 'max_height':
 				case 'limit_height':
 				case 'limit_width':
 					$sanitized_value = $this->to_bound_integer( $value, 100, 5000 );
@@ -494,8 +490,6 @@ class Optml_Settings {
 			'no_script'            => $this->get( 'no_script' ),
 			'image_replacer'       => $this->get( 'image_replacer' ),
 			'cdn'                  => $this->get( 'cdn' ),
-			'max_width'            => $this->get( 'max_width' ),
-			'max_height'           => $this->get( 'max_height' ),
 			'filters'              => $this->get_filters(),
 			'cloud_sites'          => $this->get( 'cloud_sites' ),
 			'defined_image_sizes'  => $this->get( 'defined_image_sizes' ),

--- a/inc/url_replacer.php
+++ b/inc/url_replacer.php
@@ -251,16 +251,10 @@ final class Optml_Url_Replacer extends Optml_App_Replacer {
 			}
 		}
 
-		if ( $args['width'] > 0 && $args['height'] > 0 ) {
-			list( $args['width'], $args['height'] ) = wp_constrain_dimensions( $args['width'], $args['height'], $this->max_width, $this->max_height );
-		} elseif ( $args['width'] > 0 ) {
-			$args['width'] = $args['width'] > $this->max_width ? $this->max_width : $args['width'];
-		} elseif ( $args['height'] > 0 ) {
-			$args['height'] = $args['height'] > $this->max_height ? $this->max_height : $args['height'];
-		}
 		if ( isset( $args['resize'], $args['resize']['gravity'] ) && $this->settings->is_smart_cropping() ) {
 			$args['resize']['gravity'] = Optml_Resize::GRAVITY_SMART;
 		}
+
 		$args = apply_filters( 'optml_image_args', $args, $original_url );
 
 		$arguments = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
- Removes the `Resize large images original source` setting;
- Enables the `Limit Image Dimensions` setting for old users;
- Changes the `Limit Image Dimensions` setting to be enabled by default in all cases; 

Closes #675.

### How to test the changes in this Pull Request:

1. Go to the Optimole Settings page (**Optimole Dashboard > Settings > Resize**) 
2. The `Resize large images original source` setting should not exist anymore;
3. For users that updated the plugin, the `Limit Image Dimensions` setting should be turned on now;
4. For new users, the `Limit Image Dimensions` setting should be turned on by default;
5. The setting should function just as before (https://github.com/Codeinwp/optimole-wp/pull/538), resizing images larger than 1920x1080 (or whatever limit is set under the `Limit Image Dimensions` setting);
6. You can check this by looking at the URL in the DOM - w/h should not exceed 1920/1080;

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* ~[] Have you written new tests for your changes, as applicable?~
* [x] Have you successfully ran tests with your changes locally?
 
