### PR TITLE
feat: add toast notifications system

### DIFF
--- a/assets/src/dashboard/parts/Main.js
+++ b/assets/src/dashboard/parts/Main.js
@@ -15,6 +15,7 @@ import ConnectingLayout from './connecting';
 import ConnectedLayout from './connected';
 import Footer from './Footer';
 import { highlightSidebarLink } from '../utils/helpers';
+import Toasts from './connected/Toasts';
 
 const Main = () => {
 	const allowedTabs = [ 'dashboard', 'settings', 'help' ];
@@ -117,6 +118,8 @@ const Main = () => {
 					setTab={ setTab }
 				/>
 			) }
+
+			<Toasts />
 		</>
 	);
 };

--- a/assets/src/dashboard/parts/connected/Toasts.js
+++ b/assets/src/dashboard/parts/connected/Toasts.js
@@ -1,0 +1,25 @@
+import { filter } from 'lodash';
+import { SnackbarList } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+
+export default function() {
+	const notices = useSelect(
+		( select ) => select( noticesStore ).getNotices(),
+		[]
+	);
+
+	const { removeNotice } = useDispatch( noticesStore );
+
+	const snackbarNotices = filter( notices, {
+		type: 'snackbar'
+	});
+
+	return (
+		<SnackbarList
+			notices={snackbarNotices}
+			className="px-2 bottom-4 fixed"
+			onRemove={removeNotice}
+		/>
+	);
+};

--- a/assets/src/dashboard/utils/api.js
+++ b/assets/src/dashboard/utils/api.js
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/data';
 
 import { addQueryArgs } from '@wordpress/url';
+import { store as noticesStore } from '@wordpress/notices';
 import { toggleDashboardSidebarSubmenu } from './helpers';
 
 const {
@@ -44,6 +45,9 @@ const {
 	getQueryArgs,
 	getTotalNumberOfImages
 } = select( 'optimole' );
+
+const { createNotice } = dispatch( noticesStore );
+
 
 export const sendOnboardingImages = ( data = {}) => {
 	data.offset = undefined !== data.offset ? data.offset : 0;
@@ -365,6 +369,7 @@ export const saveSettings = ( settings, refreshStats = false ) => {
 
 			if ( 'success' === response.code ) {
 				setSiteSettings( response.data );
+				addNotice( optimoleDashboardApp.strings.options_strings.settings_saved );
 				console.log( '%c Settings Saved.', 'color: #59B278' );
 			}
 		}).then( () => {
@@ -375,7 +380,7 @@ export const saveSettings = ( settings, refreshStats = false ) => {
 		})
 		.catch( error => {
 			setIsLoading( false );
-
+			addNotice( optimoleDashboardApp.strings.options_strings.settings_saved_error );
 			console.log( 'Error while saving settings', error );
 			return error.data;
 		});
@@ -396,9 +401,11 @@ export const clearCache = ( type ) => {
 			setIsLoading( false );
 
 			if ( 200 <= response.status && 300 > response.status ) {
+				addNotice( optimoleDashboardApp.strings.options_strings.cache_cleared );
 				console.log( '%c New cache token generated.', 'color: #59B278' );
 				return;
 			} else {
+				addNotice( optimoleDashboardApp.strings.options_strings.cache_cleared_error );
 				console.log( '%c Could not generate cache token.', 'color: #E7602A' );
 				return;
 			}
@@ -540,3 +547,16 @@ export const callSync = ( data ) => {
 			setLoadingRollback( false );
 		});
 };
+
+export const addNotice = ( text )  => {
+	createNotice(
+		'info',
+		text,
+		{
+			isDismissible: true,
+			type: 'snackbar'
+		}
+	);
+};
+
+

--- a/assets/src/dashboard/utils/helpers.js
+++ b/assets/src/dashboard/utils/helpers.js
@@ -110,6 +110,5 @@ const toggleDashboardSidebarSubmenu = ( show = true ) => {
 	existingList.style.display = 'block';
 };
 
-window.x = toggleDashboardSidebarSubmenu;
 
 export { toggleDamSidebarLink, highlightSidebarLink, toggleDashboardSidebarSubmenu };

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1392,6 +1392,10 @@ The root cause might be either a security plugin which blocks this feature or so
 				'no'                                => __( 'Do not restore images after disabling', 'optimole-wp' ),
 				'lazyload_placeholder_color'        => __( 'Placeholder Color', 'optimole-wp' ),
 				'clear'                             => __( 'Clear', 'optimole-wp' ),
+				'settings_saved'                   => __( 'Settings saved', 'optimole-wp' ),
+				'settings_saved_error'             => __( 'Error saving settings. Please reload the page and try again.', 'optimole-wp' ),
+				'cache_cleared'                    => __( 'Cache cleared', 'optimole-wp' ),
+				'cache_cleared_error'              => __( 'Error clearing cache. Please reload the page and try again.', 'optimole-wp' ),
 			],
 			'help'                             => [
 				'section_one_title'           => __( 'Help and Support', 'optimole-wp' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
- Adds toasts notifications system;
- Adds notifications for when settings are saved;
- Adds notifications for when cache is cleared;

Closes #696.

### How to test the changes in this Pull Request:

1. Change any settings and save, a toast notice should appear confirming the change happened;
2. Clear the cache - a toast should appear acknowledging that cache was cleared;

![image](https://github.com/Codeinwp/optimole-wp/assets/15010186/0d3e924a-8216-4e40-8ed0-74089eadb472)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* ~[ ] Have you written new tests for your changes, as applicable?~
* [x] Have you successfully ran tests with your changes locally?
 
