### PR TITLE
fix: wrong process value in Compression Ratio

### DIFF
--- a/assets/src/dashboard/parts/connected/settings/Compression.js
+++ b/assets/src/dashboard/parts/connected/settings/Compression.js
@@ -272,7 +272,7 @@ const Compression = ({
 
 											<progress
 												max={ 100 }
-												value={ getCompressionRatio() }
+												value={ 100 - getCompressionRatio() }
 											/>
 
 											<hr className="my-4 border-grayish-blue"/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
Fixes value of Progress Bar in "Enable Autoquality" option being opposite of the actual compression.
 

Closes #692.

### How to test the changes in this Pull Request:

1. In Dashboard, assuming you already have images compressed, visit the Settings and disable "Enable Auto Quality powered by ML(Machine Learning)"
2. Click on View Sample and confirm the value of Progress Bar is same as compression numbers.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
