### PR TITLE
fix: proper integration with media modal enqueue [closes #618]

### DIFF
--- a/inc/dam.php
+++ b/inc/dam.php
@@ -46,11 +46,8 @@ class Optml_Dam {
 		if ( $this->settings->get( 'cloud_images' ) === 'enabled' ) {
 			add_action( 'admin_menu', [ $this, 'add_menu' ] );
 			add_action( 'print_media_templates', [ $this, 'print_media_template' ] );
-			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_media_scripts' ] );
+			add_action( 'wp_enqueue_media', [ $this, 'enqueue_media_scripts' ] );
 			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_page_scripts' ] );
-
-			// Needed for this to work with elementor.
-			add_action( 'elementor/editor/after_enqueue_scripts', [ $this, 'enqueue_media_scripts' ] );
 		}
 
 		if ( defined( 'OPTML_DAM_ENDPOINT' ) && constant( 'OPTML_DAM_ENDPOINT' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 - Uses proper enqueue hook for media modal script (`wp_enqueue_media`);
 - Adds compatibility with all media modals loaded in the admin;
 

Closes #618.

### How to test the changes in this Pull Request:

1. Install Beaver Builder lite and enable Cloud Library browsing;
2. Edit a page with Beaver builder - cloud images should be available and work as expected;
3. Test that Elementor and the core editor integration still works fine; 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* ~[] Have you written new tests for your changes, as applicable?~
* [x] Have you successfully ran tests with your changes locally?
 
