### PR TITLE
Fix/enhace cache

### DIFF
--- a/inc/attachment_cache.php
+++ b/inc/attachment_cache.php
@@ -4,7 +4,13 @@
  * Class Optml_Attachment_Cache.
  */
 class Optml_Attachment_Cache {
-	const CACHE_GROUP = 'optml_attachment_ids';
+	const CACHE_GROUP = 'om_att';
+	/**
+	 * Local cache map.
+	 *
+	 * @var array
+	 */
+	private static $cache_map = [];
 
 	/**
 	 * Get the cached attachment ID.
@@ -14,9 +20,19 @@ class Optml_Attachment_Cache {
 	 * @return bool|mixed
 	 */
 	public static function get_cached_attachment_id( $url ) {
-		$cache_key = self::get_cache_key( $url );
 
-		return wp_cache_get( $cache_key, self::CACHE_GROUP );
+		// We cache also in memory to avoid calling DB every time when not using Object Cache.
+		$cache_key = self::get_cache_key( $url );
+		if ( isset( self::$cache_map[ $cache_key ] ) ) {
+			return self::$cache_map[ $cache_key ];
+		}
+
+		$value                         = wp_using_ext_object_cache()
+			? wp_cache_get( $cache_key, self::CACHE_GROUP )
+			: get_transient( self::CACHE_GROUP . $cache_key );
+		self::$cache_map[ $cache_key ] = $value;
+
+		return $value;
 	}
 
 	/**
@@ -29,8 +45,16 @@ class Optml_Attachment_Cache {
 	 */
 	public static function set_cached_attachment_id( $url, $id ) {
 		$cache_key = self::get_cache_key( $url );
+		// We cache also in memory to avoid calling DB every time when not using Object Cache.
+		self::$cache_map[ $cache_key ] = $id;
+		// If the ID is not found we cache for 10 minutes, otherwise for a week.
+		// We try to reduce the cache time when is not found to
+		// avoid caching for situation when this might be temporary.
+		$expiration = $id === 0 ? ( 10 * MINUTE_IN_SECONDS ) : WEEK_IN_SECONDS;
+		return wp_using_ext_object_cache()
+			? wp_cache_set( $cache_key, $id, self::CACHE_GROUP, $expiration )
+			: set_transient( self::CACHE_GROUP . $cache_key, $id, $expiration );
 
-		wp_cache_set( $cache_key, $id, self::CACHE_GROUP, DAY_IN_SECONDS );
 	}
 
 	/**
@@ -43,6 +67,6 @@ class Optml_Attachment_Cache {
 	private static function get_cache_key( $url ) {
 		$url = strtok( $url, '?' );
 
-		return 'attachment_id_' . crc32( $url );
+		return 'id_' . crc32( $url );
 	}
 }

--- a/inc/attachment_cache.php
+++ b/inc/attachment_cache.php
@@ -51,7 +51,7 @@ class Optml_Attachment_Cache {
 		// We try to reduce the cache time when is not found to
 		// avoid caching for situation when this might be temporary.
 		$expiration = $id === 0 ? ( 10 * MINUTE_IN_SECONDS ) : WEEK_IN_SECONDS;
-		return wp_using_ext_object_cache()
+		wp_using_ext_object_cache()
 			? wp_cache_set( $cache_key, $id, self::CACHE_GROUP, $expiration )
 			: set_transient( self::CACHE_GROUP . $cache_key, $id, $expiration );
 

--- a/inc/traits/dam_offload_utils.php
+++ b/inc/traits/dam_offload_utils.php
@@ -237,7 +237,7 @@ trait Optml_Dam_Offload_Utils {
 
 		$attachment_id = attachment_url_to_postid( $url );
 
-		if ( $attachment_id === 0 && $this->is_scaled_url( $url ) ) {
+		if ( $attachment_id === 0 && ! $this->is_scaled_url( $url ) ) {
 			$scaled_url = $this->get_scaled_url( $url );
 
 			$attachment_id = attachment_url_to_postid( $scaled_url );

--- a/inc/traits/dam_offload_utils.php
+++ b/inc/traits/dam_offload_utils.php
@@ -209,7 +209,16 @@ trait Optml_Dam_Offload_Utils {
 
 		return str_replace( '.' . $extension, '-scaled.' . $extension, $url );
 	}
-
+	/**
+	 * Check if the URL is a scaled image.
+	 *
+	 * @param string $url The URL to check.
+	 *
+	 * @return bool
+	 */
+	private function is_scaled_url( $url ) {
+		return strpos( $url, '-scaled.' ) !== false;
+	}
 	/**
 	 * Get the attachment ID from URL.
 	 *
@@ -228,7 +237,7 @@ trait Optml_Dam_Offload_Utils {
 
 		$attachment_id = attachment_url_to_postid( $url );
 
-		if ( $attachment_id === 0 ) {
+		if ( $attachment_id === 0 && $this->is_scaled_url( $url ) ) {
 			$scaled_url = $this->get_scaled_url( $url );
 
 			$attachment_id = attachment_url_to_postid( $scaled_url );

--- a/inc/traits/dam_offload_utils.php
+++ b/inc/traits/dam_offload_utils.php
@@ -234,10 +234,6 @@ trait Optml_Dam_Offload_Utils {
 			$attachment_id = attachment_url_to_postid( $scaled_url );
 		}
 
-		if ( $attachment_id === 0 ) {
-			return $attachment_id;
-		}
-
 		Optml_Attachment_Cache::set_cached_attachment_id( $url, $attachment_id );
 
 		return $attachment_id;


### PR DESCRIPTION
- use transients when the object cache is not available. 
- keep a cache map on the runtime memory to help reduce the load.
- reducing the cache group and key size to avoid going over the limit of the transient key length. 
- cache not found for lower time amount to avoid when this is temporary. 