### PR TITLE
Fix/division by zero

### DIFF
--- a/inc/url_replacer.php
+++ b/inc/url_replacer.php
@@ -237,7 +237,7 @@ final class Optml_Url_Replacer extends Optml_App_Replacer {
 		$args['width']  = (int) $args['width'];
 		$args['height'] = (int) $args['height'];
 
-		if ( $this->limit_dimensions_enabled ) {
+		if ( $this->limit_dimensions_enabled && $args['height'] !== 0 && $args['width'] !== 0 ) {
 			if ( $args['width'] > $this->limit_width || $args['height'] > $this->limit_height ) {
 				$scale = min( $this->limit_width / $args['width'], $this->limit_height / $args['height'] );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
 Ensures that we don't reach a division by 0 when limiting dimensions for an image.

Closes #722.

### How to test the changes in this Pull Request:

Unfortunately, I couldn't find a way to test this. It does seem to occur when one of the dimensions of the image is larger than the limit, and the other one comes in as "auto" which translates to 0. 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* ~[ ] Have you written new tests for your changes, as applicable?~
* [x] Have you successfully ran tests with your changes locally?
 
