### PR TITLE
Fixes/offloading

### DIFF
--- a/inc/attachment_cache.php
+++ b/inc/attachment_cache.php
@@ -11,7 +11,12 @@ class Optml_Attachment_Cache {
 	 * @var array
 	 */
 	private static $cache_map = [];
-
+	/**
+	 * Reset the memory cache.
+	 */
+	public static function reset() {
+		self::$cache_map = [];
+	}
 	/**
 	 * Get the cached attachment ID.
 	 *

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -540,20 +540,13 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 
 		$size       = 'full';
 		$found_size = $this->parse_dimensions_from_filename( $url );
-		$strip_url  = $url;
-		$scaled_url = $url;
+		$url        = $this->add_schema( $url );
 		if ( $found_size[0] !== false && $found_size[1] !== false ) {
-			$size       = $found_size;
-			$strip_url  = str_replace( '-' . $found_size[0] . 'x' . $found_size[1], '', $url );
-			$scaled_url = str_replace( '-' . $found_size[0] . 'x' . $found_size[1], '-scaled', $url );
-		}
-		$strip_url = $this->add_schema( $strip_url );
+			$size = $found_size;
 
-		$attachment_id = attachment_url_to_postid( $strip_url );
-		if ( $attachment_id === 0 ) {
-			$scaled_url    = $this->add_schema( $scaled_url );
-			$attachment_id = attachment_url_to_postid( $scaled_url );
 		}
+		$url           = $this->add_schema( $url );
+		$attachment_id = $this->attachment_url_to_post_id( $url );
 
 		return [ 'attachment_id' => $attachment_id, 'size' => $size ];
 	}

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -813,7 +813,8 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 		foreach ( $image_ids as $id ) {
 			if ( self::is_uploaded_image( wp_get_attachment_metadata( $id )['file'] ) ) {
 				// if this meta flag below failed at the initial update but the file meta above is updated it will cause an infinite query loop
-				update_post_meta( $id, 'optimole_offload', 'true' );
+				update_post_meta( $id, self::META_KEYS['offloaded'], 'true' );
+				update_post_meta( $id, self::OM_OFFLOADED_FLAG, true );
 				$success_up ++;
 				continue;
 			}

--- a/inc/traits/dam_offload_utils.php
+++ b/inc/traits/dam_offload_utils.php
@@ -223,21 +223,46 @@ trait Optml_Dam_Offload_Utils {
 	private function is_scaled_url( $url ) {
 		return strpos( $url, '-scaled.' ) !== false;
 	}
+
+	/**
+	 * Check if the image has been offloaded completely.
+	 *
+	 * @param int $id The attachment ID.
+	 *
+	 * @return bool
+	 */
+	private function is_completed_offload( $id ) {
+		// This is the flag that is used to mark the image as offloaded at the end.
+		$completed = ! empty( get_post_meta( $id, Optml_Media_Offload::OM_OFFLOADED_FLAG, true ) );
+		if ( $completed ) {
+			return true;
+		}
+		// In some rare cases the image is offloaded but the flag is not set so we can alternatively check this using the file path.
+		$meta = wp_get_attachment_metadata( $id );
+		if ( ! isset( $meta['file'] ) ) {
+			return false;
+		}
+		if ( Optml_Media_Offload::is_uploaded_image( $meta['file'] ) ) {
+			return true;
+		}
+
+		return false;
+	}
 	/**
 	 * Get the attachment ID from URL.
 	 *
-	 * @param string $url The attachment URL.
+	 * @param string $input_url The attachment URL.
 	 *
 	 * @return int
 	 */
-	private function attachment_url_to_post_id( $url ) {
-		$cached = Optml_Attachment_Cache::get_cached_attachment_id( $url );
+	private function attachment_url_to_post_id( $input_url ) {
+		$cached = Optml_Attachment_Cache::get_cached_attachment_id( $input_url );
 
 		if ( $cached !== false ) {
 			return $cached;
 		}
 
-		$url = $this->strip_image_size( $url );
+		$url = $this->strip_image_size( $input_url );
 
 		$attachment_id = attachment_url_to_postid( $url );
 
@@ -265,7 +290,7 @@ trait Optml_Dam_Offload_Utils {
 				$attachment_id = attachment_url_to_postid( $scaled_url );
 			}
 		}
-		Optml_Attachment_Cache::set_cached_attachment_id( $url, $attachment_id );
+		Optml_Attachment_Cache::set_cached_attachment_id( $input_url, $attachment_id );
 
 		return $attachment_id;
 	}

--- a/tests/test-media.php
+++ b/tests/test-media.php
@@ -418,6 +418,7 @@ class Test_Media extends WP_UnitTestCase {
 		$this->assertEquals( $this->attachment_url_to_post_id( $scaled_url ), self::$sample_attachment_scaled );
 	}
 	public function test_replace_urls_in_editor_content() {
+		Optml_Attachment_Cache::reset();
 		// Sample attachment:
 		$original_url = Optml_Media_Offload::get_original_url( self::$sample_attachement );
 		$extension = pathinfo( $original_url, PATHINFO_EXTENSION );


### PR DESCRIPTION
- Improve the attachment cache logic and fix an issue when the cache for the sizes URLs never occurs. 
- Fix an edge case when the offloaded images were marked as done only on the legacy system with the legacy meta but not on the new system. This can occur if the process hits some timeout and it ends prematurely. 
