### PR TITLE
Fixed optimised image issue with the WC cart page

### DIFF
--- a/inc/compatibilities/woocommerce.php
+++ b/inc/compatibilities/woocommerce.php
@@ -24,7 +24,7 @@ class Optml_woocommerce extends Optml_compatibility {
 	public function register() {
 		if ( Optml_Main::instance()->admin->settings->use_lazyload() ) {
 			add_filter( 'optml_lazyload_early_flags', [ $this, 'add_lazyload_early_flag' ], PHP_INT_MAX, 1 );
-			if ( class_exists( '\Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils', false ) && \Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils::is_cart_block_default() ) {
+			if ( class_exists( '\Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils' ) && \Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils::is_cart_block_default() ) {
 				add_filter( 'image_downsize', [ Optml_Tag_Replacer::instance(), 'filter_image_downsize' ], PHP_INT_MAX, 3 );
 			}
 		}

--- a/inc/compatibilities/woocommerce.php
+++ b/inc/compatibilities/woocommerce.php
@@ -24,8 +24,8 @@ class Optml_woocommerce extends Optml_compatibility {
 	public function register() {
 		if ( Optml_Main::instance()->admin->settings->use_lazyload() ) {
 			add_filter( 'optml_lazyload_early_flags', [ $this, 'add_lazyload_early_flag' ], PHP_INT_MAX, 1 );
-			if ( class_exists( '\Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils' ) && \Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils::is_cart_block_default() ) {
-				add_filter( 'image_downsize', [ Optml_Tag_Replacer::instance(), 'filter_image_downsize' ], PHP_INT_MAX, 3 );
+			if ( class_exists( '\Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils' ) && \Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils::is_cart_block_default() && function_exists( 'wc_cart_totals_subtotal_html' ) ) {
+				add_filter( 'image_downsize', [ $this, 'filter_cart_item_image' ], PHP_INT_MAX, 3 );
 			}
 		}
 	}
@@ -79,5 +79,21 @@ class Optml_woocommerce extends Optml_compatibility {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * This filter will replace all the images retrieved via "wp_get_image" type of functions.
+	 *
+	 * @param array        $image The filtered value.
+	 * @param int          $attachment_id The related attachment id.
+	 * @param array|string $size This could be the name of the thumbnail size or an array of custom dimensions.
+	 *
+	 * @return array
+	 */
+	public function filter_cart_item_image( $image, $attachment_id, $size ) {
+		if ( ! is_cart() ) {
+			return $image;
+		}
+		return Optml_Tag_Replacer::instance()->filter_image_downsize( $image, $attachment_id, $size );
 	}
 }

--- a/inc/compatibilities/woocommerce.php
+++ b/inc/compatibilities/woocommerce.php
@@ -24,7 +24,7 @@ class Optml_woocommerce extends Optml_compatibility {
 	public function register() {
 		if ( Optml_Main::instance()->admin->settings->use_lazyload() ) {
 			add_filter( 'optml_lazyload_early_flags', [ $this, 'add_lazyload_early_flag' ], PHP_INT_MAX, 1 );
-			if ( \Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils::is_cart_block_default() ) {
+			if ( class_exists( '\Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils', false ) && \Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils::is_cart_block_default() ) {
 				add_filter( 'image_downsize', [ Optml_Tag_Replacer::instance(), 'filter_image_downsize' ], PHP_INT_MAX, 3 );
 			}
 		}

--- a/inc/compatibilities/woocommerce.php
+++ b/inc/compatibilities/woocommerce.php
@@ -24,6 +24,9 @@ class Optml_woocommerce extends Optml_compatibility {
 	public function register() {
 		if ( Optml_Main::instance()->admin->settings->use_lazyload() ) {
 			add_filter( 'optml_lazyload_early_flags', [ $this, 'add_lazyload_early_flag' ], PHP_INT_MAX, 1 );
+			if ( \Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils::is_cart_block_default() ) {
+				add_filter( 'image_downsize', [ Optml_Tag_Replacer::instance(), 'filter_image_downsize' ], PHP_INT_MAX, 3 );
+			}
 		}
 	}
 	/**

--- a/inc/compatibilities/woocommerce.php
+++ b/inc/compatibilities/woocommerce.php
@@ -91,6 +91,9 @@ class Optml_woocommerce extends Optml_compatibility {
 	 * @return array
 	 */
 	public function filter_cart_item_image( $image, $attachment_id, $size ) {
+		if ( ! function_exists( 'is_cart' ) ) {
+			return $image;
+		}
 		if ( ! is_cart() ) {
 			return $image;
 		}

--- a/inc/tag_replacer.php
+++ b/inc/tag_replacer.php
@@ -49,13 +49,13 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 
 		parent::init();
 		add_filter( 'optml_content_images_tags', [ $this, 'process_image_tags' ], 1, 2 );
+		add_filter( 'image_downsize', [ $this, 'filter_image_downsize' ], PHP_INT_MAX, 3 );
 
 		if ( $this->settings->use_lazyload() ) {
 			return;
 		}
 
 		add_filter( 'optml_tag_replace', [ $this, 'regular_tag_replace' ], 1, 6 );
-		add_filter( 'image_downsize', [ $this, 'filter_image_downsize' ], PHP_INT_MAX, 3 );
 		add_filter( 'wp_calculate_image_srcset', [ $this, 'filter_srcset_attr' ], PHP_INT_MAX, 5 );
 		add_filter( 'wp_calculate_image_sizes', [ $this, 'filter_sizes_attr' ], 1, 2 );
 	}

--- a/inc/tag_replacer.php
+++ b/inc/tag_replacer.php
@@ -49,13 +49,13 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 
 		parent::init();
 		add_filter( 'optml_content_images_tags', [ $this, 'process_image_tags' ], 1, 2 );
-		add_filter( 'image_downsize', [ $this, 'filter_image_downsize' ], PHP_INT_MAX, 3 );
 
 		if ( $this->settings->use_lazyload() ) {
 			return;
 		}
 
 		add_filter( 'optml_tag_replace', [ $this, 'regular_tag_replace' ], 1, 6 );
+		add_filter( 'image_downsize', [ $this, 'filter_image_downsize' ], PHP_INT_MAX, 3 );
 		add_filter( 'wp_calculate_image_srcset', [ $this, 'filter_srcset_attr' ], PHP_INT_MAX, 5 );
 		add_filter( 'wp_calculate_image_sizes', [ $this, 'filter_sizes_attr' ], 1, 2 );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
It appears that the `$this->settings->use_lazyload()` condition is causing the filters to be skipped, and the `image_downsize` filter is needed to replace the optimized image and fix the issue with WC Cart items.

Closes #753

### How to test the changes in this Pull Request:

1. Add a product to the cart.
2. Check if the image is optimized on the same product page when the noticed appears on page that product is added.
3. Go to cart page and check the product images.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
 
