### PR TITLE
Fix compatibility issue elementor

### DIFF
--- a/inc/dam.php
+++ b/inc/dam.php
@@ -628,11 +628,11 @@ class Optml_Dam {
 
 		$all_sizes = $this->get_all_image_sizes();
 
-		if ( ! isset( $all_sizes[ $settings['image_size'] ] ) ) {
+		if ( ! isset( $all_sizes[ $image_size_key ] ) ) {
 			return $html;
 		}
 
-		return $this->replace_dam_url_args( $all_sizes[ $settings['image_size'] ], $html );
+		return $this->replace_dam_url_args( $all_sizes[ $image_size_key ], $html );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

I've used the elementor/image_size/get_attachment_image_html hook with the $image_size_key argument instead of $settings['image_size'] because $settings['image_size'] returns an array, which causes a fatal error.

Ref: https://tinyurl.com/2a6va6mf

I tested it with PHP 8.0 and encountered this error.

Closes #828

### How to test the changes in this Pull Request:

1. Install and activate the latest version of Elementor.
2. Install and activate the latest version of Optimole.
3. Create a new page in WordPress with Elementor.
4. Add the "Image Box" widget to the page and select the image from Optimole DAM.
5. Save the changes and attempt to view the page, you will experience some layout shifts, or unable to save the page.
6. Reload the Elementor editor screen

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
