### PR TITLE
make `--type` option optional with `clear_cache` command

### DIFF
--- a/inc/cli/cli_setting.php
+++ b/inc/cli/cli_setting.php
@@ -129,7 +129,7 @@ class Optml_Cli_Setting extends WP_CLI_Command {
 	/**
 	 * Clear cache.
 	 *
-	 * --type=<type>
+	 * [--type=<type>]
 	 * : The type of cache to clear. Default is images.
 	 */
 	public function clear_cache( $args, $assoc_args ) {


### PR DESCRIPTION
Small fix to the `clear_cache` command that I found fixing an issue for a client. It says `--type` defaults to images, but that doesn't work in practice.

![image](https://github.com/user-attachments/assets/9d48f6e6-aa6c-42c7-8d59-63f47188e4fe)
