### PR TITLE
feat: adapt for sub-api keys [ref Codeinwp/optimole-service#1136]

### DIFF
--- a/assets/src/dashboard/parts/connected/settings/CloudLibrary.js
+++ b/assets/src/dashboard/parts/connected/settings/CloudLibrary.js
@@ -17,16 +17,18 @@ export default function CloudLibrary( props ) {
 	} = props;
 
 	const storeData = useSelect( select => {
-		const { isLoading } = select( 'optimole' );
+		const { isLoading, isSubApiKey } = select( 'optimole' );
 		return {
-			isLoading: isLoading()
+			isLoading: isLoading(),
+			isSubApiKey: isSubApiKey()
 		};
 	}, []);
 
-	const { isLoading } = storeData;
+	const { isLoading, isSubApiKey } = storeData;
 
 
 	const isCloudLibraryEnabled = 'disabled' !== settings[ 'cloud_images' ];
+	const showSiteSelector = ! isSubApiKey && isCloudLibraryEnabled;
 	const whitelistedDomains = user_data.whitelist || [];
 
 
@@ -81,7 +83,7 @@ export default function CloudLibrary( props ) {
 
 			<hr className="my-8 border-grayish-blue"/>
 
-			{isCloudLibraryEnabled && (
+			{showSiteSelector && (
 				<BaseControl
 					label={options_strings.cloud_site_title}
 					help={options_strings.cloud_site_desc}

--- a/assets/src/dashboard/store/selectors.js
+++ b/assets/src/dashboard/store/selectors.js
@@ -93,6 +93,9 @@ const selectors = {
 		}
 
 		return state.logs;
+	},
+	isSubApiKey( state ) {
+		return state.apiKey && state.apiKey.startsWith( 'optml-s' );
 	}
 };
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
- Changes to adapt this with the sub-api keys integration from the optimole dashboard here https://github.com/Codeinwp/optimole-service/pull/1300
- If a sub-api key is used, it automatically hides the site selector option under Cloud Library
- The banner toggle will not work either, as that option is restricted on the dashboard to the root API key.

Closes Codeinwp/optimole-service#1136.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
