### PR TITLE
Feat: force reoffload

### DIFF
--- a/assets/src/dashboard/parts/components/Modal.js
+++ b/assets/src/dashboard/parts/components/Modal.js
@@ -12,7 +12,7 @@ export default function Modal({	icon, labels = {}, onRequestClose = () => {}, on
 		'bg-stale-yellow': 'warning' === variant,
 		'bg-light-blue': 'default' === variant
 	},
-	'p-3 rounded-full'
+	'p-2 rounded-full flex items-center justify-center'
 	);
 
 	const actionButtonClasses = classnames(
@@ -37,11 +37,12 @@ export default function Modal({	icon, labels = {}, onRequestClose = () => {}, on
 			/>
 
 			<div className="flex flex-col items-center">
-				<Icon
-					icon={ icon }
-					size={ 24 }
-					className={iconClasses}
-				/>
+				<span className={iconClasses}>
+					<Icon
+						icon={ icon }
+						size={ 24 }
+					/>
+				</span>
 
 				<h2
 					className="mb-0"

--- a/assets/src/dashboard/parts/connected/settings/OffloadMedia.js
+++ b/assets/src/dashboard/parts/connected/settings/OffloadMedia.js
@@ -6,7 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Icon } from '@wordpress/icons';
 
 import { warning, rollback as rollbackIcon, offload, warningAlt, sync } from '../../../utils/icons';
-import { callSync, checkOffloadConflicts, saveSettings } from '../../../utils/api';
+import { callSync, clearOffloadErrors, checkOffloadConflicts, saveSettings } from '../../../utils/api';
 import Notice from '../../components/Notice';
 import RadioBoxes from '../../components/RadioBoxes';
 import ProgressTile from '../../components/ProgressTile';
@@ -113,7 +113,9 @@ const OffloadMedia = ({ settings, canSave, setSettings, setCanSave }) => {
 	}, []);
 
 
-	const onOffloadMedia = ( imageIds = []) => {
+	const onOffloadMedia = async( imageIds = []) => {
+		await clearOffloadErrors();
+
 		const nextSettings = { ...settings };
 		nextSettings['show_offload_finish_notice'] = '';
 		nextSettings['offloading_status'] = 'enabled';

--- a/assets/src/dashboard/utils/api.js
+++ b/assets/src/dashboard/utils/api.js
@@ -592,6 +592,17 @@ export const callSync = ( data ) => {
 		});
 };
 
+export const clearOffloadErrors = async() => {
+	try {
+		return await apiFetch({
+			path: optimoleDashboardApp.routes['clear_offload_errors'],
+			method: 'GET'
+		});
+	} catch ( error ) {
+		console.log( error );
+	}
+};
+
 export const addNotice = ( text )  => {
 	createNotice(
 		'info',

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -2754,4 +2754,18 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 
 		return $url;
 	}
+
+	/**
+	 * Cleanup the offload errors meta.
+	 */
+	public static function clear_offload_errors_meta() {
+		global $wpdb;
+
+		$query = $wpdb->prepare(
+			"DELETE FROM {$wpdb->postmeta} WHERE meta_key = %s",
+			self::META_KEYS['offload_error']
+		);
+
+		return $wpdb->query( $query );
+	}
 }

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -2761,11 +2761,11 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 	public static function clear_offload_errors_meta() {
 		global $wpdb;
 
-		$query = $wpdb->prepare(
-			"DELETE FROM {$wpdb->postmeta} WHERE meta_key = %s",
-			self::META_KEYS['offload_error']
+		return $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->postmeta} WHERE meta_key = %s",
+				self::META_KEYS['offload_error']
+			)
 		);
-
-		return $wpdb->query( $query );
 	}
 }

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -875,7 +875,7 @@ class Optml_Rest {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public function clear_offload_errors( \WP_REST_Request $request ) {
+	public function clear_offload_errors( WP_REST_Request $request ) {
 		$delete_count = Optml_Media_Offload::clear_offload_errors_meta();
 
 		return $this->response( [ 'success' => $delete_count ] );

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -78,6 +78,7 @@ class Optml_Rest {
 		],
 		'media_cloud_routes' => [
 			'number_of_images_and_pages' => 'POST',
+			'clear_offload_errors' => 'GET',
 			'get_offload_conflicts' => 'GET',
 		],
 		'watermark_routes' => [
@@ -865,6 +866,19 @@ class Optml_Rest {
 		}
 
 		return $this->response( Optml_Media_Offload::get_image_count( $action, $refresh, $images ) );
+	}
+
+	/**
+	 * Clear the offload errors from previous offload attempts.
+	 *
+	 * @param WP_REST_Request $request Rest request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function clear_offload_errors( \WP_REST_Request $request ) {
+		$delete_count = Optml_Media_Offload::clear_offload_errors_meta();
+
+		return $this->response( [ 'success' => $delete_count ] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 - Fixes an issue with the modal icon not being displayed properly;
 - Adds a mechanism to run a cleanup of the error meta for previously offloaded attachments when the sync is ran manually;
 
Closes Codeinwp/optimole-service#1292.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* ~[ ] Have you written new tests for your changes, as applicable?~
* [x] Have you successfully ran tests with your changes locally?
 
