### PR TITLE
feat: load Formbricks survey via internal pages hooks

### DIFF
--- a/assets/src/dashboard/parts/connected/index.js
+++ b/assets/src/dashboard/parts/connected/index.js
@@ -21,41 +21,8 @@ import Help from './help';
 import Sidebar from './Sidebar';
 import CSAT from './CSAT';
 import { retrieveConflicts } from '../../utils/api';
-import formbricks from '@formbricks/js/app';
 import BlackFridayBanner from '../components/BlackFridayBanner';
-if ( 'undefined' !== typeof window && optimoleDashboardApp.user_data.plan ) {
-	formbricks.init({
-		environmentId: 'clo8wxwzj44orpm0gjchurujm',
-		apiHost: 'https://app.formbricks.com',
-		userId: 'optml_' + ( optimoleDashboardApp.user_data.id ),
-		attributes: {
-			plan: optimoleDashboardApp.user_data.plan,
-			status: optimoleDashboardApp.user_data.status,
-			language: optimoleDashboardApp.language,
-			cname_assigned: optimoleDashboardApp.user_data.is_cname_assigned || 'no',
-			connected_websites: optimoleDashboardApp.user_data.whitelist && optimoleDashboardApp.user_data.whitelist.length.toString(),
-			traffic: convertToCategory( optimoleDashboardApp.user_data.traffic || 0, 500 ).toString(),
-			images_number: convertToCategory( optimoleDashboardApp.user_data.images_number || 0, 100 ).toString(),
-			days_since_install: convertToCategory( optimoleDashboardApp.days_since_install ).toString()
-		}
-	});
 
-}
-function convertToCategory( number, scale = 1 ) {
-
-	const normalizedNumber = Math.round( number / scale );
-	if ( 0 === normalizedNumber || 1 === normalizedNumber ) {
-		return 0;
-	} else if ( 1 < normalizedNumber && 8 > normalizedNumber ) {
-		return 7;
-	} else if ( 8 <= normalizedNumber && 31 > normalizedNumber ) {
-		return 30;
-	} else if ( 30 < normalizedNumber && 90 > normalizedNumber ) {
-		return 90;
-	} else if ( 90 < normalizedNumber ) {
-		return 91;
-	}
-}
 const ConnectedLayout = ({
 	tab,
 	setTab

--- a/inc/dam.php
+++ b/inc/dam.php
@@ -536,6 +536,8 @@ class Optml_Dam {
 		wp_enqueue_script( OPTML_NAMESPACE . '-admin-page' );
 
 		wp_enqueue_style( OPTML_NAMESPACE . '-admin-page', OPTML_URL . 'assets/build/media/admin-page.css' );
+
+		do_action( 'themeisle_internal_page', OPTML_PRODUCT_SLUG, 'dam' );
 	}
 
 	/**

--- a/optimole-wp.php
+++ b/optimole-wp.php
@@ -92,6 +92,7 @@ function optml() {
 	define( 'OPTML_VERSION', '3.13.9' );
 	define( 'OPTML_NAMESPACE', 'optml' );
 	define( 'OPTML_BASEFILE', __FILE__ );
+	define( 'OPTML_PRODUCT_SLUG', basename( OPTML_PATH ) );
 	// Fallback for old PHP versions when this constant is not defined.
 	if ( ! defined( 'PHP_INT_MIN' ) ) {
 		define( 'PHP_INT_MIN', - 999999 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,9 @@
   "packages": {
     "": {
       "name": "optimole-wp",
-      "version": "3.12.10",
+      "version": "3.13.9",
       "license": "GPL-2.0+",
       "dependencies": {
-        "@formbricks/js": "^2.0.0",
         "classnames": "^2.3.2",
         "react-compare-image": "^3.4.0",
         "usehooks-ts": "^2.9.1"
@@ -2581,11 +2580,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
       "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==",
       "dev": true
-    },
-    "node_modules/@formbricks/js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@formbricks/js/-/js-2.0.0.tgz",
-      "integrity": "sha512-1T0i1zxU3cKDQ3Rxw9DXGoWwLNBEJT2pO2ELuwbGg36u6ijazLA4j61HbNUMuHgEoiyhVtLcTOZF5FquQVzr/A=="
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -33041,11 +33035,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
       "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==",
       "dev": true
-    },
-    "@formbricks/js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@formbricks/js/-/js-2.0.0.tgz",
-      "integrity": "sha512-1T0i1zxU3cKDQ3Rxw9DXGoWwLNBEJT2pO2ELuwbGg36u6ijazLA4j61HbNUMuHgEoiyhVtLcTOZF5FquQVzr/A=="
     },
     "@hapi/hoek": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "tailwindcss": "^3.3.2"
   },
   "dependencies": {
-    "@formbricks/js": "^2.0.0",
     "classnames": "^2.3.2",
     "react-compare-image": "^3.4.0",
     "usehooks-ts": "^2.9.1"

--- a/tests/static-analysis-stubs/optimole-wp.php
+++ b/tests/static-analysis-stubs/optimole-wp.php
@@ -10,6 +10,8 @@ define( 'OPTML_PATH', plugin_dir_path( __FILE__ ) );
 define( 'OPTML_VERSION', '3.7.0' );
 define( 'OPTML_NAMESPACE', 'optml' );
 define( 'OPTML_BASEFILE', __FILE__ );
+define( 'OPTML_PRODUCT_SLUG', basename( OPTML_PATH ) );
+
 if ( ! defined( 'OPTML_DEBUG' ) ) {
     define( 'OPTML_DEBUG', false );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
 - Added internal page hooks
 - Remove Formbricks as a dependency 
 - Loading survey via internal page hooks

Closes https://github.com/Codeinwp/themeisle/issues/1687

### How to test the changes in this Pull Request:

1. Use the latest Themeisle SDK release.
2. Go to `/wp-admin/admin.php?page=optimole&formbricksDebug=true#dashboard`
3. In the Browser Console you should see:

![CleanShot 2025-02-19 at 16 54 37@2x](https://github.com/user-attachments/assets/fbce6768-2b5e-42b1-96d8-6ef77784982a)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
