### PR TITLE
Fixed detach listeners after adding image

### DIFF
--- a/assets/src/media/modal/messageHandler.js
+++ b/assets/src/media/modal/messageHandler.js
@@ -55,7 +55,10 @@ class MessageHandler {
 
 		// Wait for the frame to load.
 		this.frame.addEventListener( 'load', () => {
-			document.querySelector( '.om-dam-loader:not([style])' ).style.display = 'none';
+			let damLoader = document.querySelector( '.om-dam-loader:not([style])' );
+			if ( damLoader ) {
+				damLoader.style.display = 'none';
+			}
 			this.frame.style.display = '';
 			this.frame.classList.add( 'loaded' );
 			window.addEventListener( 'message', self.messageListener );
@@ -94,6 +97,7 @@ class MessageHandler {
 			}
 
 			this.insertImages( event.data.images );
+			this.detachListeners();
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
"I've detached event listeners to fix the image insert issue in other fields."

Closes https://github.com/Codeinwp/optimole-wp/issues/670

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
