### PR TITLE
Fixed image downsize issue when lazyload disabled

### DIFF
--- a/inc/tag_replacer.php
+++ b/inc/tag_replacer.php
@@ -451,6 +451,9 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 	 */
 	public function filter_image_downsize( $image, $attachment_id, $size ) {
 
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return $image;
+		}
 		$image_url = wp_get_attachment_url( $attachment_id );
 		if ( Optml_Media_Offload::is_uploaded_image( $image_url ) ) {
 			return $image;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

Added a condition to skip image downsizing for REST API requests.

```
if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
	return $image;
}
```
 

Closes https://github.com/Codeinwp/optimole-wp/issues/704

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
