### PR TITLE
Reset exclusions filter values

### DIFF
--- a/assets/src/dashboard/parts/connected/settings/FilterControl.js
+++ b/assets/src/dashboard/parts/connected/settings/FilterControl.js
@@ -170,6 +170,9 @@ const FilterControl = ({
 		}
 
 		setCanSave( true );
+
+		setFilterValue( '' );
+		setFilterType( FILTER_TYPES.FILENAME );
 	};
 
 	const hasItems = (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
I've reset the state data after the user adds an exclusion filter. 

Closes https://github.com/Codeinwp/optimole-wp/issues/681

### How to test the changes in this Pull Request:

1. Optimole > Settings > Exclusions

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
