### PR TITLE
fix: reduce loading time for plugin connection

### DIFF
--- a/assets/src/dashboard/parts/connecting/index.js
+++ b/assets/src/dashboard/parts/connecting/index.js
@@ -24,15 +24,21 @@ const ConnectingLayout = () => {
 	const [ progress, setProgress ] = useState( 0 );
 	const [ step, setStep ] = useState( 0 );
 	const [ timer, setTimer ] = useState( 0 );
-	const maxTime = 25;
+	const maxTime = 5;
 
 	const { sethasDashboardLoaded } = useDispatch( 'optimole' );
 
 	useEffect( () => {
 		if ( timer <= maxTime ) {
-			setTimeout( () => {
+			const timeout = setTimeout( () => {
 				updateProgress();
 			}, 1000 );
+
+			return () => {
+				if ( timeout ) {
+					clearTimeout( timeout );
+				}
+			};
 		}
 	}, [ timer ]);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 - Lowers the waiting time for connection to 5 seconds instead of 25.
 

Closes Codeinwp/optimole-service#1349.

### How to test the changes in this Pull Request:

1. Either connect with an existing api key or creating a new account;
2. The loading should take a lot less than previously, while the onboarding images should be sent to the service for optimization;

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
