### PR TITLE
feat: add button for direct cloud library access

### DIFF
--- a/assets/src/dashboard/parts/connected/settings/CloudLibrary.js
+++ b/assets/src/dashboard/parts/connected/settings/CloudLibrary.js
@@ -3,9 +3,14 @@ import classnames from 'classnames';
 import {
 	BaseControl,
 	FormTokenField,
-	ToggleControl
+	ToggleControl,
+	Icon
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+
+import {
+	arrowRight
+} from '@wordpress/icons';
 
 export default function CloudLibrary( props ) {
 	const { user_data, strings } = optimoleDashboardApp;
@@ -80,6 +85,16 @@ export default function CloudLibrary( props ) {
 				)}
 				onChange={value => updateOption( 'cloud_images', value )}
 			/>
+
+			<div className="m-0">
+				<a href={options_strings.cloud_library_btn_link} className="font-semibold text-info text-sm hover:text-info inline-flex items-center">
+					{options_strings.cloud_library_btn_text}
+					<Icon
+						icon={arrowRight}
+						className="inline-block ml-2 fill-current"
+					/>
+				</a>
+			</div>
 
 			<hr className="my-8 border-grayish-blue"/>
 

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1884,6 +1884,8 @@ The root cause might be either a security plugin which blocks this feature or so
 				'rollback_stop_title'                 => __( 'Are you sure?', 'optimole-wp' ),
 				'rollback_stop_description'           => __( 'Canceling will halt the ongoing process, and any remaining images will stay in the Optimole Cloud. To transfer images to the Optimole Cloud, use the Offloading option.', 'optimole-wp' ),
 				'rollback_stop_action'                => __( 'Cancel the transfer from Optimole', 'optimole-wp' ),
+				'cloud_library_btn_text'              => __( 'Go to Cloud Library', 'optimole-wp' ),
+				'cloud_library_btn_link'              => add_query_arg( 'page', 'optimole-dam', admin_url( 'admin.php' ) ),
 			],
 			'help'                           => [
 				'section_one_title'           => __( 'Help and Support', 'optimole-wp' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

Added a button for direct access to the cloud library.

Closes https://github.com/Codeinwp/optimole-service/issues/1339

### How to test the changes in this Pull Request:

Optimole -> settings -> Cloud Library

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 