### PR TITLE
feat: move image storage menu

### DIFF
--- a/assets/src/dashboard/parts/components/RadioBoxes.js
+++ b/assets/src/dashboard/parts/components/RadioBoxes.js
@@ -16,7 +16,7 @@ export default function RadioBoxes({ options, value, onChange, label, disabled =
 			onChange={handleClick}
 		>
 
-			{label && <legend className="uppercase font-semibold text-s text-light-black mb-6">{label}</legend>}
+			{label && <legend className="uppercase font-semibold text-s text-light-black mb-6 inline-block">{label}</legend>}
 
 			{options.map( ( option, index ) => {
 				const { title, value: buttonValue, description } = option;

--- a/assets/src/dashboard/parts/connected/settings/Menu.js
+++ b/assets/src/dashboard/parts/connected/settings/Menu.js
@@ -21,6 +21,10 @@ const menuItems = [
 		value: 'general'
 	},
 	{
+		label: strings.image_storage,
+		value: 'offload_media'
+	},
+	{
 		label: strings.advanced_settings_menu_item,
 		value: 'compression',
 		children: [
@@ -45,10 +49,6 @@ const menuItems = [
 	{
 		label: strings.cloud_library,
 		value: 'cloud_library'
-	},
-	{
-		label: strings.image_storage,
-		value: 'offload_media'
 	}
 ];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

- Moved `Image Storage` menu before the `Advanced Settings` menu.  
- Fixed broken text issue on Safari.

Closes https://github.com/Codeinwp/optimole-service/issues/1340

### How to test the changes in this Pull Request:

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
