### PR TITLE
feat: rework sidebar width in plugin admin [closes Codeinwp/optimole-service#1337]

### DIFF
--- a/assets/src/dashboard/parts/connected/Sidebar.js
+++ b/assets/src/dashboard/parts/connected/Sidebar.js
@@ -41,7 +41,7 @@ const Sidebar = () => {
 	});
 
 	return (
-		<div className="grid md:grid-cols-2 xl:flex xl:flex-col xl:mt-8 xl:mb-5 p-0 transition-all ease-in-out duration-700 gap-5 basis-4/12 2xl:basis-3/12">
+		<div className="grid md:grid-cols-2 xl:flex xl:flex-col xl:mt-8 xl:mb-5 p-0 transition-all ease-in-out duration-700 gap-5 shrink-0 xl:w-[350px]">
 			<div className="bg-white gap-5 flex flex-col text-gray-700 border-0 rounded-lg shadow-md p-8">
 				<TextControl
 					label={ optimoleDashboardApp.strings.logged_in_as }

--- a/assets/src/dashboard/parts/connected/index.js
+++ b/assets/src/dashboard/parts/connected/index.js
@@ -123,7 +123,7 @@ const ConnectedLayout = ({
 
 			<div className="flex flex-col xl:flex-row mx-auto gap-5">
 				<div
-					className="flex flex-col justify-between mt-8 xl:mb-5 p-0 transition-all ease-in-out duration-700 relative text-gray-700 basis-8/12 2xl:basis-9/12"
+					className="flex flex-col justify-between mt-8 xl:mb-5 p-0 transition-all ease-in-out duration-700 relative text-gray-700 grow"
 				>
 					{ 'dashboard' === tab && <Dashboard /> }
 


### PR DESCRIPTION


### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

- Lowers sidebar width in plugin admin to a width of 350px when in horizontal layout. 
 
![image](https://github.com/user-attachments/assets/edb39869-9ff5-4241-9d5f-40b9ead971ff)

Closes Codeinwp/optimole-service#1337.

### How to test the changes in this Pull Request:

1. Install the plugin;
2. Check if the sidebar width is 350px;

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
