### PR TITLE
fix: disable image scaling when lazyload is off

### DIFF
--- a/assets/src/dashboard/parts/connected/OptimizationStatus.js
+++ b/assets/src/dashboard/parts/connected/OptimizationStatus.js
@@ -10,6 +10,7 @@ const OptimizationStatus = () => {
 	const statuses = useSelect( select => {
 		const { getSiteSettings } = select( 'optimole' );
 		const siteSettings = getSiteSettings();
+		const lazyloadEnabled = 'enabled' === siteSettings?.lazyload;
 		return [
 			{
 				active: 'enabled' === siteSettings?.image_replacer,
@@ -17,12 +18,12 @@ const OptimizationStatus = () => {
 				description: optimoleDashboardApp.strings.optimization_status.statusSubTitle1
 			},
 			{
-				active: 'enabled' === siteSettings?.lazyload,
+				active: lazyloadEnabled,
 				label: optimoleDashboardApp.strings.optimization_status.statusTitle2,
 				description: optimoleDashboardApp.strings.optimization_status.statusSubTitle2
 			},
 			{
-				active: 'disabled' === siteSettings?.scale,
+				active: lazyloadEnabled && 'disabled' === siteSettings?.scale,
 				label: optimoleDashboardApp.strings.optimization_status.statusTitle3,
 				description: optimoleDashboardApp.strings.optimization_status.statusSubTitle3
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

Marked image scaling feature as disabled when lazy load is inactive.
 

Closes https://github.com/Codeinwp/optimole-service/issues/1347#issuecomment-2751702745


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?