### PR TITLE
feat: hide bagde toggle if the user is inactive [ref Codeinwp/optimole-service#1438]

### DIFF
--- a/assets/src/dashboard/parts/connected/settings/General.js
+++ b/assets/src/dashboard/parts/connected/settings/General.js
@@ -31,11 +31,12 @@ const General = ({
 	setSettings,
 	setCanSave
 }) => {
-	const { isLoading } = useSelect( select => {
-		const { isLoading } = select( 'optimole' );
+	const { isLoading, isUserActive } = useSelect( select => {
+		const { isLoading, getUserStatus } = select( 'optimole' );
 
 		return {
-			isLoading: isLoading()
+			isLoading: isLoading(),
+			isUserActive: 'active' === getUserStatus()
 		};
 	});
 
@@ -91,88 +92,91 @@ const General = ({
 
 			<hr className="my-8 border-grayish-blue"/>
 
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.enable_badge_title }
-				help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_badge_description } } /> }
-				checked={ isBannerEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
-				) }
-				onChange={ ( value ) => {
-					updateOption( 'banner_frontend', value );
-					setBadgeSettings( value );
-				} }
-			/>
+			{ isUserActive && <>
+				<ToggleControl
+					label={ optimoleDashboardApp.strings.options_strings.enable_badge_title }
+					help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_badge_description } } /> }
+					checked={ isBannerEnabled }
+					disabled={ isLoading }
+					className={ classnames(
+						{
+							'is-disabled': isLoading
+						}
+					) }
+					onChange={ ( value ) => {
+						updateOption( 'banner_frontend', value );
+						setBadgeSettings( value );
+					} }
+				/>
 
-			{ isBannerEnabled && (
-				<div className="mt-4 badge-settings">
-					<Button
-						className={ classnames(
-							'border border-none bg-transparent text-blue-500 px-2 py-1 rounded-sm flex items-center cursor-pointer',
-							{
-								'is-disabled': isLoading
-							}
-						) }
-						onClick={ () => setBadgeSettings( ! showBadgeSettings ) }
-					>
-						<span>{ optimoleDashboardApp.strings.options_strings.enable_badge_settings }</span>
-						<Icon
-							icon={ showBadgeSettings ? chevronUp : chevronDown }
-							className="h-5 w-5"
-							style={{ fill: '#3b82f6' }}
-						/>
-					</Button>
-					{ showBadgeSettings && (
-						<div class="mt-4 space-y-4 pl-4 pt-2">
-							<div class="flex items-center justify-between mb-4">
-								<label class="text-gray-600 font-medium">{ optimoleDashboardApp.strings.options_strings.enable_badge_show_icon }</label>
-								<ToggleControl
-									label=""
-									checked={ isShowBadgeIcon }
-									disabled={ isLoading }
-									className={ classnames(
-										'flex items-center justify-between mb-4',
-										{
-											'is-disabled': isLoading
-										}
-									) }
-									onChange={ value => updateOption( 'show_badge_icon', value ) }
-								/>
-							</div>
-							<div class="flex items-center justify-between">
-								<label class="text-gray-600 font-medium">{ optimoleDashboardApp.strings.options_strings.enable_badge_position }</label>
-								<div class="flex space-x-2">
-									<Button
+				{ isBannerEnabled && (
+					<div className="mt-4 badge-settings">
+						<Button
+							className={ classnames(
+								'border border-none bg-transparent text-blue-500 px-2 py-1 rounded-sm flex items-center cursor-pointer',
+								{
+									'is-disabled': isLoading
+								}
+							) }
+							onClick={ () => setBadgeSettings( ! showBadgeSettings ) }
+						>
+							<span>{ optimoleDashboardApp.strings.options_strings.enable_badge_settings }</span>
+							<Icon
+								icon={ showBadgeSettings ? chevronUp : chevronDown }
+								className="h-5 w-5"
+								style={{ fill: '#3b82f6' }}
+							/>
+						</Button>
+						{ showBadgeSettings && (
+							<div class="mt-4 space-y-4 pl-4 pt-2">
+								<div class="flex items-center justify-between mb-4">
+									<label class="text-gray-600 font-medium">{ optimoleDashboardApp.strings.options_strings.enable_badge_show_icon }</label>
+									<ToggleControl
+										label=""
+										checked={ isShowBadgeIcon }
+										disabled={ isLoading }
 										className={ classnames(
-											'px-4 py-2 border rounded border-[1px]',
-											'left' === activeBadgePosition ? 'border-blue-500 text-blue-500 bg-blue-100' : 'border-gray-300 text-gray-500 bg-gray-100',
+											'flex items-center justify-between mb-4',
 											{
 												'is-disabled': isLoading
 											}
 										) }
-										onClick={ () => updateOption( 'badge_position', 'left' ) }
-									>{ optimoleDashboardApp.strings.options_strings.badge_position_text_1 }</Button>
-									<Button
-										className={ classnames(
-											'px-4 py-2 border rounded',
-											'right' === activeBadgePosition ? 'border-blue-500 text-blue-500 bg-blue-100' : 'border-gray-300 text-gray-500 bg-gray-100',
-											{
-												'is-disabled': isLoading
-											}
-										) }
-										onClick={ () => updateOption( 'badge_position', 'right' ) }
-									>{ optimoleDashboardApp.strings.options_strings.badge_position_text_2 }</Button>
+										onChange={ value => updateOption( 'show_badge_icon', value ) }
+									/>
+								</div>
+								<div class="flex items-center justify-between">
+									<label class="text-gray-600 font-medium">{ optimoleDashboardApp.strings.options_strings.enable_badge_position }</label>
+									<div class="flex space-x-2">
+										<Button
+											className={ classnames(
+												'px-4 py-2 border rounded border-[1px]',
+												'left' === activeBadgePosition ? 'border-blue-500 text-blue-500 bg-blue-100' : 'border-gray-300 text-gray-500 bg-gray-100',
+												{
+													'is-disabled': isLoading
+												}
+											) }
+											onClick={ () => updateOption( 'badge_position', 'left' ) }
+										>{ optimoleDashboardApp.strings.options_strings.badge_position_text_1 }</Button>
+										<Button
+											className={ classnames(
+												'px-4 py-2 border rounded',
+												'right' === activeBadgePosition ? 'border-blue-500 text-blue-500 bg-blue-100' : 'border-gray-300 text-gray-500 bg-gray-100',
+												{
+													'is-disabled': isLoading
+												}
+											) }
+											onClick={ () => updateOption( 'badge_position', 'right' ) }
+										>{ optimoleDashboardApp.strings.options_strings.badge_position_text_2 }</Button>
+									</div>
 								</div>
 							</div>
-						</div>
-					)}
-				</div>
-			)}
+						)}
+					</div>
+				)}
 
-			<hr className="my-8 border-grayish-blue"/>
+				<hr className="my-8 border-grayish-blue"/>
+
+			</>}
 
 			<BaseControl
 				label={ optimoleDashboardApp.strings.options_strings.cache_title }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
- Hides the badge setting for inactive users.
 

Closes Codeinwp/optimole-service#1438 .

### How to test the changes in this Pull Request:

1. Deactivate the user on the dashboard;
2. Refresh the stats and check that the badge setting is hidden;


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
