### PR TITLE
Refactor media offload functionality and enhance REST API integration

### DIFF
--- a/assets/js/media.js
+++ b/assets/js/media.js
@@ -1,6 +1,6 @@
 jQuery(document).ready(function($) {
     jQuery('.move-image-optml').click(function() {
-        //ge the id and send a jquery rest request to the server
+        //get the id and send a jquery rest request to the server
         var id = jQuery(this).data('id');
         var action = jQuery(this).data('action'); 
         moveImage(id, action, jQuery(this));

--- a/assets/js/media.js
+++ b/assets/js/media.js
@@ -1,0 +1,42 @@
+jQuery(document).ready(function($) {
+    jQuery('.move-image-optml').click(function() {
+        //ge the id and send a jquery rest request to the server
+        var id = jQuery(this).data('id');
+        var action = jQuery(this).data('action'); 
+        moveImage(id, action, jQuery(this));
+    }); 
+});
+
+function moveImage(id, action, element, is_retry = false) {
+    //add a loading indicator
+    element.parent().find('.spinner').addClass('is-active');
+    element.parent().addClass('is-loading');
+    jQuery.ajax({
+        url:  optimoleMediaListing.rest_url,
+        type: 'POST',
+        headers: {
+            'X-WP-Nonce': optimoleMediaListing.nonce
+        },
+        data: {
+            action: action,
+            status: is_retry ? 'check' : 'start',
+            id: id  
+        },
+        success: function(response) {
+            if(response.code === 'moved') {
+                element.parent().find('.spinner').removeClass('is-active');
+                element.parent().removeClass('is-loading'); 
+                element.parent().find('.move-image-optml').toggleClass('hidden'); 
+
+            }else if(response.code === 'error'){
+                element.parent().find('.spinner').removeClass('is-active');
+                element.parent().removeClass('is-loading'); 
+                element.parent().text(response.data);
+            }else{
+                setTimeout(function() {
+                    moveImage(id, action, element, true);
+                }, 1000);
+            }
+        }
+    });
+}

--- a/assets/src/dashboard/parts/connected/index.js
+++ b/assets/src/dashboard/parts/connected/index.js
@@ -64,27 +64,6 @@ const ConnectedLayout = ({
 	const [ canSave, setCanSave ] = useState( false );
 	const [ settings, setSettings ] = useState( siteSettings );
 
-	useEffect( () => {
-		const urlSearchParams = new URLSearchParams( window.location.search );
-		const params = Object.fromEntries( urlSearchParams.entries() );
-		let images = [];
-
-		if ( Object.prototype.hasOwnProperty.call( params, 'optimole_action' ) ) {
-			for ( let i = 0; 20 > i; i++ ) {
-				if ( Object.prototype.hasOwnProperty.call( params, i ) ) {
-					if ( ! isNaN( params[i]) ) {
-						images[i] = parseInt( params[i], 10 );
-					}
-				}
-			}
-
-			params.images = images;
-			params.url = window.location.href.split( '?' )[0] + ( Object.prototype.hasOwnProperty.call( params, 'paged' ) ? '?paged=' + params.paged : '' );
-			setQueryArgs( params );
-			setTab( 'settings' );
-			setMenu( 'offload_media' );
-		}
-	}, []);
 
 	useEffect( () => {
 		if ( isConnected && hasApplication ) {

--- a/assets/src/dashboard/parts/connected/settings/Compression.js
+++ b/assets/src/dashboard/parts/connected/settings/Compression.js
@@ -15,7 +15,10 @@ import {
 	Button,
 	Icon,
 	RangeControl,
-	ToggleControl
+	ToggleControl,
+
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption
 } from '@wordpress/components';
 
 import { useSelect } from '@wordpress/data';
@@ -56,7 +59,7 @@ const Compression = ({
 	const isStripMetadataEnabled = 'disabled' !== settings[ 'strip_metadata' ];
 	const isAutoQualityEnabled = 'disabled' !== settings.autoquality;
 	const isBestFormatEnabled = 'disabled' !== settings[ 'best_format' ];
-
+	const compressionMode = settings[ 'compression_mode' ];
 	const isRetinaEnabled = 'disabled' !== settings[ 'retina_images' ];
 	const updateOption = ( option, value ) => {
 		setCanSave( true );
@@ -115,194 +118,289 @@ const Compression = ({
 
 		return ( parseFloat( sampleImages.optimized_size / sampleImages.original_size ) * 100 ).toFixed( 0 );
 	};
+	let customSettings = {
 
+	};
+	const saveCustomSettings = () => {
+		customSettings = {
+			best_format: 'enabled' === settings.best_format ? true : false,
+			retina_images: 'enabled' === settings.retina_images ? true : false,
+			network_optimization: 'enabled' === settings.network_optimization ? true : false,
+			avif: 'enabled' === settings.avif ? true : false,
+			strip_metadata: 'enabled' === settings.strip_metadata ? true : false,
+			autoquality: 'enabled' === settings.autoquality ? true : false
+		};
+	};
+	const transformCompressionMode = ( value ) => {
+		if ( 'custom' === compressionMode && 'custom' !== value ) {
+
+			//If user already changed those before, we need to save them so if he switch back to custom, we can use the old settings
+			saveCustomSettings();
+		}
+		setCanSave( true );
+		const data = { ...settings };
+		if ( 'speed_optimized' === value ) {
+			data[ 'best_format' ] = 'disabled';
+			data[ 'retina_images' ] = 'disabled';
+			data[ 'network_optimization' ] = 'enabled';
+			data.avif = 'mauto';
+			data.autoquality = 'enabled';
+			data[ 'strip_metadata' ] = 'enabled';
+		}
+
+		if ( 'quality_optimized' === value ) {
+			data[ 'best_format' ] = 'enabled';
+			data[ 'retina_images' ] = 'enabled';
+			data[ 'network_optimization' ] = 'disabled';
+			data.avif = 'enabled';
+			data.autoquality = 'enabled';
+			data[ 'strip_metadata' ] = 'enabled';
+		}
+		if ( 'custom' === value ) {
+			data[ 'best_format' ] = ( customSettings.best_format ?? isBestFormatEnabled ) ? 'enabled' : 'disabled';
+			data[ 'retina_images' ] = ( customSettings.retina_images ?? isRetinaEnabled ) ? 'enabled' : 'disabled';
+			data[ 'network_optimization' ] = ( customSettings.network_optimization ?? isNetworkOptimizationEnabled ) ? 'enabled' : 'disabled';
+			data.avif = ( customSettings.avif ?? isAVIFEnabled ) ? 'enabled' : 'disabled';
+			data.autoquality = ( customSettings.autoquality ?? isAutoQualityEnabled ) ? 'enabled' : 'disabled';
+			data[ 'strip_metadata' ] = ( customSettings.strip_metadata ?? isStripMetadataEnabled ) ? 'enabled' : 'disabled';
+		}
+		data.compression_mode = value;
+		setSettings( data );
+	};
 	return (
 		<>
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.best_format_title }
-				help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.best_format_desc } } /> }
-				checked={ isBestFormatEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
+
+			<ToggleGroupControl className=" w-4/6"
+				aria-label={ optimoleDashboardApp.strings.options_strings.compression_mode }
+				onChange={ value => transformCompressionMode( value ) }
+				value={ compressionMode }
+				label={ (
+					<div className="mb-4">
+						<strong>{optimoleDashboardApp.strings.options_strings.compression_mode}</strong>
+					</div>
 				) }
-				onChange={ value => updateOption( 'best_format', value ) }
-			/>
-
-			<hr className="my-8 border-grayish-blue"/>
-
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.enable_retina_title }
-				help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_retina_desc } } /> }
-				checked={ isRetinaEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
-				) }
-				onChange={ value => updateOption( 'retina_images', value ) }
-			/>
-			<hr className="my-8 border-grayish-blue"/>
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.enable_network_opt_title }
-				help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_network_opt_desc } } /> }
-				checked={ isNetworkOptimizationEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
-				) }
-				onChange={ value => updateOption( 'network_optimization', value ) }
-			/>
-
-			<hr className="my-8 border-grayish-blue"/>
-
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.toggle_cdn }
-				help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.cdn_desc } } /> }
-				checked={ isCDNEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
-				) }
-				onChange={ value => updateOption( 'cdn', value ) }
-			/>
-
-			<hr className="my-8 border-grayish-blue"/>
-
-
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.enable_avif_title }
-				help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_avif_desc } } /> }
-				checked={ isAVIFEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
-				) }
-				onChange={ value => updateOption( 'avif', value ) }
-			/>
-
-			<hr className="my-8 border-grayish-blue"/>
-
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.strip_meta_title }
-				help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.strip_meta_desc } } /> }
-				checked={ isStripMetadataEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
-				) }
-				onChange={ value => updateOption( 'strip_metadata', value ) }
-			/>
-
-			<hr className="my-8 border-grayish-blue"/>
-
-			<BaseControl
-				help={ ! isAutoQualityEnabled && optimoleDashboardApp.strings.options_strings.quality_desc }
 			>
-				<ToggleControl
-					label={ optimoleDashboardApp.strings.options_strings.quality_title }
-					help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.ml_quality_desc } } /> }
-					checked={ isAutoQualityEnabled }
-					disabled={ isLoading }
-					className={ classnames(
-						{
-							'is-disabled': isLoading
-						}
-					) }
-					onChange={ value => updateOption( 'autoquality', value ) }
+				<ToggleGroupControlOption className="bg-blue-500"
+					label={ optimoleDashboardApp.strings.options_strings.compression_mode_speed_optimized }
+					value="speed_optimized"
 				/>
-			</BaseControl>
+				<ToggleGroupControlOption
+					label={ optimoleDashboardApp.strings.options_strings.compression_mode_quality_optimized }
+					value="quality_optimized"
+				/>
+				<ToggleGroupControlOption
+					label={ optimoleDashboardApp.strings.options_strings.compression_mode_custom }
+					value="custom"
+				/>
+			</ToggleGroupControl>
+			{'speed_optimized' === compressionMode && (
+				<p className="text-sm text-gray-600 mb-20">
+					{optimoleDashboardApp.strings.options_strings.compression_mode_speed_optimized_desc}
 
-			{ ! isAutoQualityEnabled && (
+				</p>
+			)}
+			{'quality_optimized' === compressionMode && (
+				<p className="text-sm text-gray-600 mb-20">
+					{optimoleDashboardApp.strings.options_strings.compression_mode_quality_optimized_desc}
+				</p>
+			)}
+			{'custom' === compressionMode && (
 				<>
-					<RangeControl
-						value={ getQuality( settings.quality ) }
-						min={ 50 }
-						max={ 100 }
-						step={ 1 }
-						withInputField={ false }
-						marks={ [
+					<p className="text-sm text-gray-600 mb-10">
+						{optimoleDashboardApp.strings.options_strings.compression_mode_custom_desc}
+					</p>
+				</>
+			)}
+			{ 'custom' === compressionMode && (
+				<>
+					<hr className="my-8 border-grayish-blue"/>
+					<ToggleControl
+						label={ optimoleDashboardApp.strings.options_strings.best_format_title }
+						help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.best_format_desc } } /> }
+						checked={ isBestFormatEnabled }
+						disabled={ isLoading }
+						className={ classnames(
 							{
-								value: 55,
-								label: optimoleDashboardApp.strings.options_strings.low_q_title
-							},
-							{
-								value: 75,
-								label: optimoleDashboardApp.strings.options_strings.medium_q_title
-							},
-							{
-								value: 90,
-								label: optimoleDashboardApp.strings.options_strings.high_q_title
+								'is-disabled': isLoading
 							}
-						] }
-						onChange={ updateQuality }
+						) }
+						onChange={ value => updateOption( 'best_format', value ) }
 					/>
 
-					{ showSample && (
-						<div className="flex justify-center w-full text-center">
-							{ isSampleLoading ? (
-								<div className="flex items-center gap-5">
-									<p className="text-base">{ optimoleDashboardApp.strings.options_strings.sample_image_loading }</p>
+					<hr className="my-8 border-grayish-blue"/>
 
-									<Icon
-										icon={ rotateRight }
-										className="animate-spin"
-									/>
-								</div>
-							) : (
-								<>
-									{ ( sampleImages.id && 0 < sampleImages.original_size ) && (
-										<div>
-											{ 0 < getCompressionRatio() ? (
-												<p className="text-base">{ 100 - getCompressionRatio() }% { optimoleDashboardApp.strings.latest_images.smaller }</p>
-											) : (
-												<p className="text-base">{ optimoleDashboardApp.strings.latest_images.same_size }</p>
+					<ToggleControl
+						label={ optimoleDashboardApp.strings.options_strings.enable_retina_title }
+						help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_retina_desc } } /> }
+						checked={ isRetinaEnabled }
+						disabled={ isLoading }
+						className={ classnames(
+							{
+								'is-disabled': isLoading
+							}
+						) }
+						onChange={ value => updateOption( 'retina_images', value ) }
+					/>
+					<hr className="my-8 border-grayish-blue"/>
+					<ToggleControl
+						label={ optimoleDashboardApp.strings.options_strings.enable_network_opt_title }
+						help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_network_opt_desc } } /> }
+						checked={ isNetworkOptimizationEnabled }
+						disabled={ isLoading }
+						className={ classnames(
+							{
+								'is-disabled': isLoading
+							}
+						) }
+						onChange={ value => updateOption( 'network_optimization', value ) }
+					/>
+
+					<hr className="my-8 border-grayish-blue"/>
+
+					<ToggleControl
+						label={ optimoleDashboardApp.strings.options_strings.toggle_cdn }
+						help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.cdn_desc } } /> }
+						checked={ isCDNEnabled }
+						disabled={ isLoading }
+						className={ classnames(
+							{
+								'is-disabled': isLoading
+							}
+						) }
+						onChange={ value => updateOption( 'cdn', value ) }
+					/>
+
+					<hr className="my-8 border-grayish-blue"/>
+
+
+					<ToggleControl
+						label={ optimoleDashboardApp.strings.options_strings.enable_avif_title }
+						help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_avif_desc } } /> }
+						checked={ isAVIFEnabled }
+						disabled={ isLoading }
+						className={ classnames(
+							{
+								'is-disabled': isLoading
+							}
+						) }
+						onChange={ value => updateOption( 'avif', value ) }
+					/>
+
+					<hr className="my-8 border-grayish-blue"/>
+
+					<ToggleControl
+						label={ optimoleDashboardApp.strings.options_strings.strip_meta_title }
+						help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.strip_meta_desc } } /> }
+						checked={ isStripMetadataEnabled }
+						disabled={ isLoading }
+						className={ classnames(
+							{
+								'is-disabled': isLoading
+							}
+						) }
+						onChange={ value => updateOption( 'strip_metadata', value ) }
+					/>
+
+					<hr className="my-8 border-grayish-blue"/>
+
+					<BaseControl
+						help={ ! isAutoQualityEnabled && optimoleDashboardApp.strings.options_strings.quality_desc }
+					>
+						<ToggleControl
+							label={ optimoleDashboardApp.strings.options_strings.quality_title }
+							help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.ml_quality_desc } } /> }
+							checked={ isAutoQualityEnabled }
+							disabled={ isLoading }
+							className={ classnames(
+								{
+									'is-disabled': isLoading
+								}
+							) }
+							onChange={ value => updateOption( 'autoquality', value ) }
+						/>
+					</BaseControl>
+
+					{ ! isAutoQualityEnabled && (
+						<>
+							<RangeControl
+								value={ getQuality( settings.quality ) }
+								min={ 50 }
+								max={ 100 }
+								step={ 1 }
+								withInputField={ false }
+								marks={ [
+									{
+										value: 55,
+										label: optimoleDashboardApp.strings.options_strings.low_q_title
+									},
+									{
+										value: 75,
+										label: optimoleDashboardApp.strings.options_strings.medium_q_title
+									},
+									{
+										value: 90,
+										label: optimoleDashboardApp.strings.options_strings.high_q_title
+									}
+								] }
+								onChange={ updateQuality }
+							/>
+
+							{ showSample && (
+								<div className="flex justify-center w-full text-center">
+									{ isSampleLoading ? (
+										<div className="flex items-center gap-5">
+											<p className="text-base">{ optimoleDashboardApp.strings.options_strings.sample_image_loading }</p>
+
+											<Icon
+												icon={ rotateRight }
+												className="animate-spin"
+											/>
+										</div>
+									) : (
+										<>
+											{ ( sampleImages.id && 0 < sampleImages.original_size ) && (
+												<div>
+													{ 0 < getCompressionRatio() ? (
+														<p className="text-base">{ 100 - getCompressionRatio() }% { optimoleDashboardApp.strings.latest_images.smaller }</p>
+													) : (
+														<p className="text-base">{ optimoleDashboardApp.strings.latest_images.same_size }</p>
+													) }
+
+													<ProgressBar
+														max={ 100 }
+														value={ 100 - getCompressionRatio() }
+													/>
+
+													<hr className="my-4 border-grayish-blue"/>
+
+													<ReactCompareImage
+														leftImageLabel={ optimoleDashboardApp.strings.options_strings.image_1_label }
+														rightImageLabel={ optimoleDashboardApp.strings.options_strings.image_2_label }
+														leftImage={ sampleImages.original }
+														rightImage={ sampleImages.optimized }
+													/>
+
+													<Button
+														variant="default"
+														icon={ rotateRight }
+														className="mt-2"
+														onClick={ loadSample }
+													/>
+
+													<p className="text-base">{ optimoleDashboardApp.strings.options_strings.quality_slider_desc }</p>
+												</div>
 											) }
 
-											<ProgressBar
-												max={ 100 }
-												value={ 100 - getCompressionRatio() }
-											/>
-
-											<hr className="my-4 border-grayish-blue"/>
-
-											<ReactCompareImage
-												leftImageLabel={ optimoleDashboardApp.strings.options_strings.image_1_label }
-												rightImageLabel={ optimoleDashboardApp.strings.options_strings.image_2_label }
-												leftImage={ sampleImages.original }
-												rightImage={ sampleImages.optimized }
-											/>
-
-											<Button
-												variant="default"
-												icon={ rotateRight }
-												className="mt-2"
-												onClick={ loadSample }
-											/>
-
-											<p className="text-base">{ optimoleDashboardApp.strings.options_strings.quality_slider_desc }</p>
-										</div>
+											{ ( ! ( sampleImages.id && 0 < sampleImages.original_size ) && 0 > sampleImages.id ) && (
+												<div className="flex items-center gap-5 text-center">
+													<p className="text-base">{ optimoleDashboardApp.strings.options_strings.no_images_found }</p>
+												</div>
+											) }
+										</>
 									) }
-
-									{ ( ! ( sampleImages.id && 0 < sampleImages.original_size ) && 0 > sampleImages.id ) && (
-										<div className="flex items-center gap-5 text-center">
-											<p className="text-base">{ optimoleDashboardApp.strings.options_strings.no_images_found }</p>
-										</div>
-									) }
-								</>
+								</div>
 							) }
-						</div>
+						</>
 					) }
 				</>
 			) }

--- a/assets/src/dashboard/parts/connected/settings/OffloadMedia.js
+++ b/assets/src/dashboard/parts/connected/settings/OffloadMedia.js
@@ -82,19 +82,6 @@ const OffloadMedia = ({ settings, canSave, setSettings, setCanSave }) => {
 	const isOffloadingInProgress = 'disabled' !== settings['offloading_status'];
 	const isRollbackInProgress = 'disabled' !== settings['rollback_status'];
 
-	useEffect( () => {
-		if ( ! queryArgs?.optimole_action || ! queryArgs?.images ) {
-			return;
-		}
-
-		if ( 'offload_images' === queryArgs.optimole_action ) {
-			onOffloadMedia( queryArgs.images );
-		}
-
-		if ( 'rollback_images' === queryArgs.optimole_action ) {
-			onRollbackdMedia( queryArgs.images );
-		}
-	}, []);
 
 	useEffect( () => {
 		if ( isOffloadingInProgress ) {
@@ -126,8 +113,7 @@ const OffloadMedia = ({ settings, canSave, setSettings, setCanSave }) => {
 			setOffloadLimitReached( false );
 
 			callSync({
-				action: 'offload_images',
-				images: imageIds
+				action: 'offload_images'
 			});
 
 			setCanSave( false );
@@ -148,8 +134,7 @@ const OffloadMedia = ({ settings, canSave, setSettings, setCanSave }) => {
 					setProcessedImages( 0 );
 
 					callSync({
-						action: 'rollback_images',
-						images: imageIds
+						action: 'rollback_images'
 					});
 
 					setCanSave( false );

--- a/assets/src/dashboard/style.scss
+++ b/assets/src/dashboard/style.scss
@@ -73,7 +73,18 @@ $mango-yellow: #FBBF24;
 			}
 		}
 	}
-
+	.components-toggle-group-control-option-base{
+	  	color: var(--wp-components-color-foreground);
+		&[aria-checked="true"]{
+			color:white;
+		}
+		+ div > div{
+			background: var(--wp-components-color-foreground);
+		}
+	} 
+	.components-toggle-group-control{
+		border-color: var(--wp-components-color-foreground);
+	}
 	.base-control-label {
 		color: #363636;
 		display: block;
@@ -440,6 +451,7 @@ $mango-yellow: #FBBF24;
 			margin-left: -14px;
 		}
 	}
+
 }
 
 .om-notice {

--- a/assets/src/dashboard/utils/api.js
+++ b/assets/src/dashboard/utils/api.js
@@ -497,15 +497,13 @@ export const callSync = ( data ) => {
 
 	setIsLoading( true );
 
-	const images_ids = undefined !== data.images ? data.images : [];
 
 	apiFetch({
 		path: optimoleDashboardApp.routes['number_of_images_and_pages'],
 		method: 'POST',
 		data: {
 			action: data.action,
-			refresh: data.refresh || false,
-			images: images_ids
+			refresh: data.refresh || false
 		},
 		parse: false
 	})
@@ -577,8 +575,7 @@ export const callSync = ( data ) => {
 			setTimeout( () => {
 				callSync({
 					action: data.action,
-					refresh: true,
-					images: images_ids
+					refresh: true
 				});
 			}, 10000 );
 		})

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1141,7 +1141,7 @@ class Optml_Admin {
 			$this->settings->update( 'rollback_status', 'enabled' );
 			// We start the rollback process.
 			Optml_Logger::instance()->add_log( 'rollback_images', 'Account deactivated, starting rollback.' );
-			Optml_Media_Offload::get_image_count( 'rollback_images', false );
+			Optml_Media_Offload::move_images( 'rollback_images', false );
 			$this->settings->update( 'offload_media', 'disabled' );
 		}
 		remove_filter( 'optml_dont_trigger_settings_updated', '__return_true' );
@@ -1282,7 +1282,33 @@ class Optml_Admin {
 		if ( ! isset( $current_screen->id ) ) {
 			return;
 		}
+		if ( $current_screen->id === 'upload' ) {
+			wp_enqueue_script( OPTML_NAMESPACE . '-media-admin', OPTML_URL . 'assets/js/media.js', [], OPTML_VERSION );
+			wp_localize_script(
+				OPTML_NAMESPACE . '-media-admin',
+				'optimoleMediaListing',
+				[
+					'rest_url' => rest_url( OPTML_NAMESPACE . '/v1/move_image' ),
+					'nonce' => wp_create_nonce( 'wp_rest' ),
+				]
+			);
 
+			wp_register_style( 'optml_media_admin_style', false );
+			wp_add_inline_style(
+				'optml_media_admin_style',
+				'
+				.is-loading {
+					pointer-events: none;
+					opacity: 0.5;
+					display: inline-block;
+				}
+				.spinner {
+					margin-top: 0px;
+				}
+			'
+			);
+			wp_enqueue_style( 'optml_media_admin_style' );
+		}
 		if ( $current_screen->id !== 'toplevel_page_optimole' ) {
 			return;
 		}

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -342,6 +342,7 @@ class Optml_Admin {
 		$this->settings->update( 'best_format', 'disabled' );
 		$this->settings->update( 'skip_lazyload_images', '2' );
 		$this->settings->update( 'avif', 'disabled' );
+		$this->settings->update( 'compression_mode', 'speed_optimized' );
 
 		update_option( self::NEW_USER_DEFAULTS_UPDATED, 'yes' );
 	}
@@ -1749,6 +1750,14 @@ The root cause might be either a security plugin which blocks this feature or so
 				'metricsSubtitle4' => __( 'During last month', 'optimole-wp' ),
 			],
 			'options_strings'                => [
+				'compression_mode'               => __( 'Compression Mode', 'optimole-wp' ),
+				'compression_mode_speed_optimized'                => __( 'Speed Optimized', 'optimole-wp' ),
+				'compression_mode_quality_optimized'              => __( 'Quality Optimized', 'optimole-wp' ),
+				'compression_mode_custom'                         => __( 'Custom', 'optimole-wp' ),
+				'compression_mode_speed_optimized_desc'           => __( 'Prioritizes faster loading and smaller image sizes by applying a balanced level of lossy compression. This setting reduces file size significantly without severely degrading visual quality.', 'optimole-wp' ),
+				'compression_mode_quality_optimized_desc'         => __( 'Delivers high-quality images by applying lossless or near-lossless optimization. Ensures images retain their sharpness and details while still benefiting from moderate file size reduction.', 'optimole-wp' ),
+				'compression_mode_custom_desc'                   => __( 'Customize each setting individually for complete control over image compression.', 'optimole-wp' ),
+
 				'best_format_title'                   => __( 'Automatic Best Image Format Selection', 'optimole-wp' ),
 				'best_format_desc'                    => sprintf(
 				/* translators: 1 is the starting anchor tag, 2 is the ending anchor tag */

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -158,7 +158,8 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 
 				add_action( 'delete_attachment', [ self::$instance, 'delete_attachment_hook' ], 10 );
 				add_filter( 'handle_bulk_actions-upload', [ self::$instance, 'bulk_action_handler' ], 10, 3 );
-				add_filter( 'bulk_actions-upload', [ self::$instance, 'register_bulk_media_actions' ] );
+				// TODO: Uncomment this when bulk actions are implemented
+				// add_filter( 'bulk_actions-upload', [ self::$instance, 'register_bulk_media_actions' ] );
 				add_filter( 'media_row_actions', [ self::$instance, 'add_inline_media_action' ], 10, 2 );
 				add_filter( 'wp_calculate_image_srcset', [ self::$instance, 'calculate_image_srcset' ], 1, 5 );
 				add_action( 'post_updated', [ self::$instance, 'update_offload_meta' ], 10, 3 );

--- a/inc/media_offload.php
+++ b/inc/media_offload.php
@@ -6,6 +6,7 @@
  * @author     Optimole <friends@optimole.com>
  */
 
+use OptimoleWP\Offload\Loader;
 use Optimole\Sdk\Exception\InvalidArgumentException;
 use Optimole\Sdk\Exception\InvalidUploadApiResponseException;
 use Optimole\Sdk\Exception\RuntimeException;
@@ -186,6 +187,7 @@ class Optml_Media_Offload extends Optml_App_Replacer {
 				if ( self::$is_legacy_install === null ) {
 					self::$is_legacy_install = get_option( 'optimole_wp_install', 0 ) > 1677171600;
 				}
+				( new Loader() )->register_hooks();
 			}
 		}
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -71,6 +71,7 @@ class Optml_Settings {
 		'resize_smart'               => 'disabled',
 		'no_script'                  => 'disabled',
 		'filters'                    => [],
+		'compression_mode'           => 'custom',
 		'cloud_sites'                => [ 'all' => 'true' ],
 		'watchers'                   => '',
 		'quality'                    => 'auto',
@@ -296,6 +297,9 @@ class Optml_Settings {
 				case 'lazyload_type':
 					$sanitized_value = $this->to_map_values( $value, [ 'fixed', 'viewport', 'all' ], 'fixed' );
 					break;
+				case 'compression_mode':
+					$sanitized_value = $this->to_map_values( $value, [ 'speed_optimized', 'quality_optimized', 'custom' ], 'custom' );
+					break;
 				case 'cloud_sites':
 					$current_sites   = $this->get( 'cloud_sites' );
 					$sanitized_value = array_replace_recursive( $current_sites, $value );
@@ -517,6 +521,7 @@ class Optml_Settings {
 			'resize_smart'               => $this->get( 'resize_smart' ),
 			'no_script'                  => $this->get( 'no_script' ),
 			'lazyload_type'              => $this->get( 'lazyload_type' ),
+			'compression_mode'           => $this->get( 'compression_mode' ),
 			'image_replacer'             => $this->get( 'image_replacer' ),
 			'cdn'                        => $this->get( 'cdn' ),
 			'filters'                    => $this->get_filters(),

--- a/inc/v2/Offload/ImageEditor.php
+++ b/inc/v2/Offload/ImageEditor.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace OptimoleWP\Offload;
+
+use Optml_Config;
+use Optml_Media_Offload;
+use WP_Error;
+
+/**
+ * Class ImageEditor
+ *
+ * Custom image editor implementation for Optimole offloaded images.
+ * This class extends WP_Image_Editor to handle images that have been offloaded
+ * to Optimole's servers, preventing local editing operations on remote images.
+ *
+ * @package OptimoleWP\Offload
+ */
+class ImageEditor extends \WP_Image_Editor {
+	/**
+	 * Tests whether this editor can handle the given file.
+	 *
+	 * @param array $args Arguments to test the editor.
+	 * @return bool True if the file is an offloaded image, false otherwise.
+	 */
+	public static function test( $args = [] ) {
+		if ( isset( $args['path'] ) && Optml_Media_Offload::is_uploaded_image( $args['path'] ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if this editor supports the given MIME type.
+	 *
+	 * @param string $mime_type The MIME type to check.
+	 * @return bool True if the MIME type is supported, false otherwise.
+	 */
+	public static function supports_mime_type( $mime_type ) {
+		return in_array( $mime_type, Optml_Config::$image_extensions, true );
+	}
+
+	/**
+	 * Saves the image to a file.
+	 *
+	 * For offloaded images, this operation is not supported and always returns false.
+	 *
+	 * @param string $destfilename Optional. The destination filename.
+	 * @param string $mime_type Optional. The MIME type of the image.
+	 * @return array|WP_Error {
+	 *     Array on success or WP_Error if the file failed to save.
+	 *
+	 *     @type string $path      Path to the image file.
+	 *     @type string $file      Name of the image file.
+	 *     @type int    $width     Image width.
+	 *     @type int    $height    Image height.
+	 *     @type string $mime-type The mime type of the image.
+	 *     @type int    $filesize  File size of the image.
+	 * }
+	 */
+	public function save( $destfilename = null, $mime_type = null ) {
+		return false; // @phpstan-ignore-line
+	}
+
+	/**
+	 * Loads the image file.
+	 *
+	 * @return bool True if the file is an offloaded image, false otherwise.
+	 */
+	public function load() {
+		if ( isset( $this->file ) && Optml_Media_Offload::is_uploaded_image( $this->file ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Resizes the image.
+	 *
+	 * For offloaded images, this operation is not performed locally and always returns true.
+	 *
+	 * @param int  $max_w Maximum width.
+	 * @param int  $max_h Maximum height.
+	 * @param bool $crop Optional. Whether to crop the image. Default false.
+	 * @return bool Always returns true for offloaded images.
+	 */
+	public function resize( $max_w, $max_h, $crop = false ) {
+		return true;
+	}
+
+	/**
+	 * Resizes the image to multiple sizes.
+	 *
+	 * For offloaded images, this operation is not performed locally and always returns an empty array.
+	 *
+	 * @param array $sizes Array of size arrays. Each size array must include width, height, crop.
+	 * @return array Empty array for offloaded images.
+	 */
+	public function multi_resize( $sizes ) {
+		return [];
+	}
+
+	/**
+	 * Crops the image.
+	 *
+	 * For offloaded images, this operation is not performed locally and always returns true.
+	 *
+	 * @param int  $src_x The start x position to crop from.
+	 * @param int  $src_y The start y position to crop from.
+	 * @param int  $src_w The width to crop.
+	 * @param int  $src_h The height to crop.
+	 * @param int  $dst_w Optional. The destination width.
+	 * @param int  $dst_h Optional. The destination height.
+	 * @param bool $src_abs Optional. If the source crop points are absolute.
+	 * @return bool Always returns true for offloaded images.
+	 */
+	public function crop( $src_x, $src_y, $src_w, $src_h, $dst_w = null, $dst_h = null, $src_abs = false ) {
+		return true;
+	}
+
+	/**
+	 * Rotates the image.
+	 *
+	 * For offloaded images, this operation is not performed locally and always returns true.
+	 *
+	 * @param float $angle The angle of rotation.
+	 * @return bool Always returns true for offloaded images.
+	 */
+	public function rotate( $angle ) {
+		return true;
+	}
+
+	/**
+	 * Flips the image.
+	 *
+	 * For offloaded images, this operation is not performed locally and always returns true.
+	 *
+	 * @param bool $horz Whether to flip horizontally.
+	 * @param bool $vert Whether to flip vertically.
+	 * @return bool Always returns true for offloaded images.
+	 */
+	public function flip( $horz, $vert ) {
+		return true;
+	}
+
+	/**
+	 * Streams the image to the browser.
+	 *
+	 * For offloaded images, this redirects to the remote image URL.
+	 *
+	 * @param string $mime_type Optional. The MIME type of the image.
+	 */
+	public function stream( $mime_type = null ) {
+		header( 'Location: ' . esc_url( $this->file ) );
+		return true;
+	}
+}

--- a/inc/v2/Offload/Loader.php
+++ b/inc/v2/Offload/Loader.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace OptimoleWP\Offload;
+
+/**
+ * Class Loader
+ *
+ * Handles the registration of custom image editors for the Optimole WordPress plugin.
+ * This class is responsible for integrating Optimole's custom image processing
+ * capabilities into WordPress's image editing system.
+ *
+ * @package OptimoleWP\Offload
+ */
+class Loader {
+
+	/**
+	 * Constructor for the Loader class.
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Register WordPress hooks needed for the image editor functionality.
+	 *
+	 * Adds filters to integrate the custom image editor into WordPress.
+	 */
+	public function register_hooks() {
+		add_filter( 'wp_image_editors', [ $this, 'register_image_editor' ] );
+	}
+
+	/**
+	 * Register the custom ImageEditor class to WordPress's image editors list.
+	 *
+	 * Adds Optimole's custom ImageEditor to the beginning of WordPress's image editors array,
+	 * giving it priority over the default editors.
+	 *
+	 * @param array $editors Array of image editor class names.
+	 * @return array Modified array of image editor class names.
+	 */
+	public function register_image_editor( $editors ) {
+		array_unshift( $editors, ImageEditor::class );
+		return $editors;
+	}
+}


### PR DESCRIPTION
Removed bulk actions support and implement inline offload/rollback of images for better experience. 

- Replaced `get_image_count` with `move_images` in the media offload process for better clarity.
- Updated the rollback process to use `move_images` instead of `get_image_count`.
- Introduced a new REST API endpoint for moving images, allowing for offloading and rollback actions.
- Enhanced the admin interface by adding scripts and styles for the media management screen.
- Improved action handling for image processing, ensuring better performance and user experience.
 https://github.com/Codeinwp/optimole-wp/issues/834
  
