### PR TITLE
Implement compression mode settings in the dashboard

### DIFF
--- a/assets/src/dashboard/parts/connected/settings/Compression.js
+++ b/assets/src/dashboard/parts/connected/settings/Compression.js
@@ -65,8 +65,6 @@ const Compression = ({
 		setCanSave( true );
 		const data = { ...settings };
 		data[ option ] = value ? 'enabled' : 'disabled';
-		console.log( option, value, data );
-
 		setSettings( data );
 	};
 

--- a/assets/src/dashboard/parts/connected/settings/Compression.js
+++ b/assets/src/dashboard/parts/connected/settings/Compression.js
@@ -15,7 +15,10 @@ import {
 	Button,
 	Icon,
 	RangeControl,
-	ToggleControl
+	ToggleControl,
+
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption
 } from '@wordpress/components';
 
 import { useSelect } from '@wordpress/data';
@@ -56,12 +59,14 @@ const Compression = ({
 	const isStripMetadataEnabled = 'disabled' !== settings[ 'strip_metadata' ];
 	const isAutoQualityEnabled = 'disabled' !== settings.autoquality;
 	const isBestFormatEnabled = 'disabled' !== settings[ 'best_format' ];
-
+	const compressionMode = settings[ 'compression_mode' ];
 	const isRetinaEnabled = 'disabled' !== settings[ 'retina_images' ];
 	const updateOption = ( option, value ) => {
 		setCanSave( true );
 		const data = { ...settings };
 		data[ option ] = value ? 'enabled' : 'disabled';
+		console.log( option, value, data );
+
 		setSettings( data );
 	};
 
@@ -107,7 +112,12 @@ const Compression = ({
 		data.quality = value;
 		setSettings( data );
 	};
-
+	const updateCompressionMode = ( value ) => {
+		setCanSave( true );
+		const data = { ...settings };
+		data.compression_mode = value;
+		setSettings( data );
+	};
 	const getCompressionRatio = () => {
 		if ( sampleImages.optimized_size > sampleImages.original_size ) {
 			return Math.floor( Math.random() * 60 ) + 10;
@@ -115,194 +125,286 @@ const Compression = ({
 
 		return ( parseFloat( sampleImages.optimized_size / sampleImages.original_size ) * 100 ).toFixed( 0 );
 	};
+	let customSettings = {
 
+	};
+	const saveCustomSettings = () => {
+		customSettings = {
+			best_format: 'enabled' === settings.best_format ? true : false,
+			retina_images: 'enabled' === settings.retina_images ? true : false,
+			network_optimization: 'enabled' === settings.network_optimization ? true : false,
+			avif: 'enabled' === settings.avif ? true : false,
+			strip_metadata: 'enabled' === settings.strip_metadata ? true : false
+		};
+	};
+	const transformCompressionMode = ( value ) => {
+		if ( 'custom' === compressionMode && 'custom' !== value ) {
+
+			//If user already changed those before, we need to save them so if he switch back to custom, we can use the old settings
+			saveCustomSettings();
+		}
+
+		const data = { ...settings };
+		if ( 'speed_optimized' === value ) {
+			data[ 'best_format' ] = 'disabled';
+			data[ 'retina_images' ] = 'disabled';
+			data[ 'network_optimization' ] = 'enabled';
+			data.avif = 'enabled';
+			data[ 'strip_metadata' ] = 'enabled';
+		}
+
+		if ( 'quality_optimized' === value ) {
+			data[ 'best_format' ] = 'enabled';
+			data[ 'retina_images' ] = 'enabled';
+			data[ 'network_optimization' ] = 'disabled';
+			data.avif = 'enabled';
+			data[ 'strip_metadata' ] = 'disabled';
+		}
+		if ( 'custom' === value ) {
+			data[ 'best_format' ] = ( customSettings.best_format ?? isBestFormatEnabled ) ? 'enabled' : 'disabled';
+			data[ 'retina_images' ] = ( customSettings.retina_images ?? isRetinaEnabled ) ? 'enabled' : 'disabled';
+			data[ 'network_optimization' ] = ( customSettings.network_optimization ?? isNetworkOptimizationEnabled ) ? 'enabled' : 'disabled';
+			data.avif = ( customSettings.avif ?? isAVIFEnabled ) ? 'enabled' : 'disabled';
+			data[ 'strip_metadata' ] = ( customSettings.strip_metadata ?? isStripMetadataEnabled ) ? 'enabled' : 'disabled';
+		}
+		setSettings( data );
+		updateCompressionMode( value );
+
+	};
 	return (
 		<>
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.best_format_title }
-				help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.best_format_desc } } /> }
-				checked={ isBestFormatEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
+
+			<ToggleGroupControl className=" w-4/6"
+				aria-label={ optimoleDashboardApp.strings.options_strings.compression_mode }
+				onChange={ value => transformCompressionMode( value ) }
+				value={ compressionMode }
+				label={ (
+					<div className="mb-4">
+						<strong>{optimoleDashboardApp.strings.options_strings.compression_mode}</strong>
+					</div>
 				) }
-				onChange={ value => updateOption( 'best_format', value ) }
-			/>
-
-			<hr className="my-8 border-grayish-blue"/>
-
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.enable_retina_title }
-				help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_retina_desc } } /> }
-				checked={ isRetinaEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
-				) }
-				onChange={ value => updateOption( 'retina_images', value ) }
-			/>
-			<hr className="my-8 border-grayish-blue"/>
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.enable_network_opt_title }
-				help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_network_opt_desc } } /> }
-				checked={ isNetworkOptimizationEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
-				) }
-				onChange={ value => updateOption( 'network_optimization', value ) }
-			/>
-
-			<hr className="my-8 border-grayish-blue"/>
-
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.toggle_cdn }
-				help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.cdn_desc } } /> }
-				checked={ isCDNEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
-				) }
-				onChange={ value => updateOption( 'cdn', value ) }
-			/>
-
-			<hr className="my-8 border-grayish-blue"/>
-
-
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.enable_avif_title }
-				help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_avif_desc } } /> }
-				checked={ isAVIFEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
-				) }
-				onChange={ value => updateOption( 'avif', value ) }
-			/>
-
-			<hr className="my-8 border-grayish-blue"/>
-
-			<ToggleControl
-				label={ optimoleDashboardApp.strings.options_strings.strip_meta_title }
-				help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.strip_meta_desc } } /> }
-				checked={ isStripMetadataEnabled }
-				disabled={ isLoading }
-				className={ classnames(
-					{
-						'is-disabled': isLoading
-					}
-				) }
-				onChange={ value => updateOption( 'strip_metadata', value ) }
-			/>
-
-			<hr className="my-8 border-grayish-blue"/>
-
-			<BaseControl
-				help={ ! isAutoQualityEnabled && optimoleDashboardApp.strings.options_strings.quality_desc }
 			>
-				<ToggleControl
-					label={ optimoleDashboardApp.strings.options_strings.quality_title }
-					help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.ml_quality_desc } } /> }
-					checked={ isAutoQualityEnabled }
-					disabled={ isLoading }
-					className={ classnames(
-						{
-							'is-disabled': isLoading
-						}
-					) }
-					onChange={ value => updateOption( 'autoquality', value ) }
+				<ToggleGroupControlOption className="bg-blue-500"
+					label={ optimoleDashboardApp.strings.options_strings.compression_mode_speed_optimized }
+					value="speed_optimized"
 				/>
-			</BaseControl>
+				<ToggleGroupControlOption
+					label={ optimoleDashboardApp.strings.options_strings.compression_mode_quality_optimized }
+					value="quality_optimized"
+				/>
+				<ToggleGroupControlOption
+					label={ optimoleDashboardApp.strings.options_strings.compression_mode_custom }
+					value="custom"
+				/>
+			</ToggleGroupControl>
+			{'speed_optimized' === compressionMode && (
+				<p className="text-sm text-gray-600 mb-20">
+					{optimoleDashboardApp.strings.options_strings.compression_mode_speed_optimized_desc}
 
-			{ ! isAutoQualityEnabled && (
+				</p>
+			)}
+			{'quality_optimized' === compressionMode && (
+				<p className="text-sm text-gray-600 mb-20">
+					{optimoleDashboardApp.strings.options_strings.compression_mode_quality_optimized_desc}
+				</p>
+			)}
+			{'custom' === compressionMode && (
 				<>
-					<RangeControl
-						value={ getQuality( settings.quality ) }
-						min={ 50 }
-						max={ 100 }
-						step={ 1 }
-						withInputField={ false }
-						marks={ [
+					<p className="text-sm text-gray-600 mb-10">
+						{optimoleDashboardApp.strings.options_strings.compression_mode_custom_desc}
+					</p>
+				</>
+			)}
+			{ 'custom' === compressionMode && (
+				<>
+					<hr className="my-8 border-grayish-blue"/>
+					<ToggleControl
+						label={ optimoleDashboardApp.strings.options_strings.best_format_title }
+						help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.best_format_desc } } /> }
+						checked={ isBestFormatEnabled }
+						disabled={ isLoading }
+						className={ classnames(
 							{
-								value: 55,
-								label: optimoleDashboardApp.strings.options_strings.low_q_title
-							},
-							{
-								value: 75,
-								label: optimoleDashboardApp.strings.options_strings.medium_q_title
-							},
-							{
-								value: 90,
-								label: optimoleDashboardApp.strings.options_strings.high_q_title
+								'is-disabled': isLoading
 							}
-						] }
-						onChange={ updateQuality }
+						) }
+						onChange={ value => updateOption( 'best_format', value ) }
 					/>
 
-					{ showSample && (
-						<div className="flex justify-center w-full text-center">
-							{ isSampleLoading ? (
-								<div className="flex items-center gap-5">
-									<p className="text-base">{ optimoleDashboardApp.strings.options_strings.sample_image_loading }</p>
+					<hr className="my-8 border-grayish-blue"/>
 
-									<Icon
-										icon={ rotateRight }
-										className="animate-spin"
-									/>
-								</div>
-							) : (
-								<>
-									{ ( sampleImages.id && 0 < sampleImages.original_size ) && (
-										<div>
-											{ 0 < getCompressionRatio() ? (
-												<p className="text-base">{ 100 - getCompressionRatio() }% { optimoleDashboardApp.strings.latest_images.smaller }</p>
-											) : (
-												<p className="text-base">{ optimoleDashboardApp.strings.latest_images.same_size }</p>
+					<ToggleControl
+						label={ optimoleDashboardApp.strings.options_strings.enable_retina_title }
+						help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_retina_desc } } /> }
+						checked={ isRetinaEnabled }
+						disabled={ isLoading }
+						className={ classnames(
+							{
+								'is-disabled': isLoading
+							}
+						) }
+						onChange={ value => updateOption( 'retina_images', value ) }
+					/>
+					<hr className="my-8 border-grayish-blue"/>
+					<ToggleControl
+						label={ optimoleDashboardApp.strings.options_strings.enable_network_opt_title }
+						help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_network_opt_desc } } /> }
+						checked={ isNetworkOptimizationEnabled }
+						disabled={ isLoading }
+						className={ classnames(
+							{
+								'is-disabled': isLoading
+							}
+						) }
+						onChange={ value => updateOption( 'network_optimization', value ) }
+					/>
+
+					<hr className="my-8 border-grayish-blue"/>
+
+					<ToggleControl
+						label={ optimoleDashboardApp.strings.options_strings.toggle_cdn }
+						help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.cdn_desc } } /> }
+						checked={ isCDNEnabled }
+						disabled={ isLoading }
+						className={ classnames(
+							{
+								'is-disabled': isLoading
+							}
+						) }
+						onChange={ value => updateOption( 'cdn', value ) }
+					/>
+
+					<hr className="my-8 border-grayish-blue"/>
+
+
+					<ToggleControl
+						label={ optimoleDashboardApp.strings.options_strings.enable_avif_title }
+						help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.enable_avif_desc } } /> }
+						checked={ isAVIFEnabled }
+						disabled={ isLoading }
+						className={ classnames(
+							{
+								'is-disabled': isLoading
+							}
+						) }
+						onChange={ value => updateOption( 'avif', value ) }
+					/>
+
+					<hr className="my-8 border-grayish-blue"/>
+
+					<ToggleControl
+						label={ optimoleDashboardApp.strings.options_strings.strip_meta_title }
+						help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.strip_meta_desc } } /> }
+						checked={ isStripMetadataEnabled }
+						disabled={ isLoading }
+						className={ classnames(
+							{
+								'is-disabled': isLoading
+							}
+						) }
+						onChange={ value => updateOption( 'strip_metadata', value ) }
+					/>
+
+					<hr className="my-8 border-grayish-blue"/>
+
+					<BaseControl
+						help={ ! isAutoQualityEnabled && optimoleDashboardApp.strings.options_strings.quality_desc }
+					>
+						<ToggleControl
+							label={ optimoleDashboardApp.strings.options_strings.quality_title }
+							help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.ml_quality_desc } } /> }
+							checked={ isAutoQualityEnabled }
+							disabled={ isLoading }
+							className={ classnames(
+								{
+									'is-disabled': isLoading
+								}
+							) }
+							onChange={ value => updateOption( 'autoquality', value ) }
+						/>
+					</BaseControl>
+
+					{ ! isAutoQualityEnabled && (
+						<>
+							<RangeControl
+								value={ getQuality( settings.quality ) }
+								min={ 50 }
+								max={ 100 }
+								step={ 1 }
+								withInputField={ false }
+								marks={ [
+									{
+										value: 55,
+										label: optimoleDashboardApp.strings.options_strings.low_q_title
+									},
+									{
+										value: 75,
+										label: optimoleDashboardApp.strings.options_strings.medium_q_title
+									},
+									{
+										value: 90,
+										label: optimoleDashboardApp.strings.options_strings.high_q_title
+									}
+								] }
+								onChange={ updateQuality }
+							/>
+
+							{ showSample && (
+								<div className="flex justify-center w-full text-center">
+									{ isSampleLoading ? (
+										<div className="flex items-center gap-5">
+											<p className="text-base">{ optimoleDashboardApp.strings.options_strings.sample_image_loading }</p>
+
+											<Icon
+												icon={ rotateRight }
+												className="animate-spin"
+											/>
+										</div>
+									) : (
+										<>
+											{ ( sampleImages.id && 0 < sampleImages.original_size ) && (
+												<div>
+													{ 0 < getCompressionRatio() ? (
+														<p className="text-base">{ 100 - getCompressionRatio() }% { optimoleDashboardApp.strings.latest_images.smaller }</p>
+													) : (
+														<p className="text-base">{ optimoleDashboardApp.strings.latest_images.same_size }</p>
+													) }
+
+													<ProgressBar
+														max={ 100 }
+														value={ 100 - getCompressionRatio() }
+													/>
+
+													<hr className="my-4 border-grayish-blue"/>
+
+													<ReactCompareImage
+														leftImageLabel={ optimoleDashboardApp.strings.options_strings.image_1_label }
+														rightImageLabel={ optimoleDashboardApp.strings.options_strings.image_2_label }
+														leftImage={ sampleImages.original }
+														rightImage={ sampleImages.optimized }
+													/>
+
+													<Button
+														variant="default"
+														icon={ rotateRight }
+														className="mt-2"
+														onClick={ loadSample }
+													/>
+
+													<p className="text-base">{ optimoleDashboardApp.strings.options_strings.quality_slider_desc }</p>
+												</div>
 											) }
 
-											<ProgressBar
-												max={ 100 }
-												value={ 100 - getCompressionRatio() }
-											/>
-
-											<hr className="my-4 border-grayish-blue"/>
-
-											<ReactCompareImage
-												leftImageLabel={ optimoleDashboardApp.strings.options_strings.image_1_label }
-												rightImageLabel={ optimoleDashboardApp.strings.options_strings.image_2_label }
-												leftImage={ sampleImages.original }
-												rightImage={ sampleImages.optimized }
-											/>
-
-											<Button
-												variant="default"
-												icon={ rotateRight }
-												className="mt-2"
-												onClick={ loadSample }
-											/>
-
-											<p className="text-base">{ optimoleDashboardApp.strings.options_strings.quality_slider_desc }</p>
-										</div>
+											{ ( ! ( sampleImages.id && 0 < sampleImages.original_size ) && 0 > sampleImages.id ) && (
+												<div className="flex items-center gap-5 text-center">
+													<p className="text-base">{ optimoleDashboardApp.strings.options_strings.no_images_found }</p>
+												</div>
+											) }
+										</>
 									) }
-
-									{ ( ! ( sampleImages.id && 0 < sampleImages.original_size ) && 0 > sampleImages.id ) && (
-										<div className="flex items-center gap-5 text-center">
-											<p className="text-base">{ optimoleDashboardApp.strings.options_strings.no_images_found }</p>
-										</div>
-									) }
-								</>
+								</div>
 							) }
-						</div>
+						</>
 					) }
 				</>
 			) }

--- a/assets/src/dashboard/parts/connected/settings/Compression.js
+++ b/assets/src/dashboard/parts/connected/settings/Compression.js
@@ -127,7 +127,8 @@ const Compression = ({
 			retina_images: 'enabled' === settings.retina_images ? true : false,
 			network_optimization: 'enabled' === settings.network_optimization ? true : false,
 			avif: 'enabled' === settings.avif ? true : false,
-			strip_metadata: 'enabled' === settings.strip_metadata ? true : false
+			strip_metadata: 'enabled' === settings.strip_metadata ? true : false,
+			autoquality: 'enabled' === settings.autoquality ? true : false
 		};
 	};
 	const transformCompressionMode = ( value ) => {
@@ -142,7 +143,8 @@ const Compression = ({
 			data[ 'best_format' ] = 'disabled';
 			data[ 'retina_images' ] = 'disabled';
 			data[ 'network_optimization' ] = 'enabled';
-			data.avif = 'enabled';
+			data.avif = 'mauto';
+			data.autoquality = 'enabled';
 			data[ 'strip_metadata' ] = 'enabled';
 		}
 
@@ -151,13 +153,15 @@ const Compression = ({
 			data[ 'retina_images' ] = 'enabled';
 			data[ 'network_optimization' ] = 'disabled';
 			data.avif = 'enabled';
-			data[ 'strip_metadata' ] = 'disabled';
+			data.autoquality = 'enabled';
+			data[ 'strip_metadata' ] = 'enabled';
 		}
 		if ( 'custom' === value ) {
 			data[ 'best_format' ] = ( customSettings.best_format ?? isBestFormatEnabled ) ? 'enabled' : 'disabled';
 			data[ 'retina_images' ] = ( customSettings.retina_images ?? isRetinaEnabled ) ? 'enabled' : 'disabled';
 			data[ 'network_optimization' ] = ( customSettings.network_optimization ?? isNetworkOptimizationEnabled ) ? 'enabled' : 'disabled';
 			data.avif = ( customSettings.avif ?? isAVIFEnabled ) ? 'enabled' : 'disabled';
+			data.autoquality = ( customSettings.autoquality ?? isAutoQualityEnabled ) ? 'enabled' : 'disabled';
 			data[ 'strip_metadata' ] = ( customSettings.strip_metadata ?? isStripMetadataEnabled ) ? 'enabled' : 'disabled';
 		}
 		data.compression_mode = value;

--- a/assets/src/dashboard/parts/connected/settings/Compression.js
+++ b/assets/src/dashboard/parts/connected/settings/Compression.js
@@ -110,12 +110,7 @@ const Compression = ({
 		data.quality = value;
 		setSettings( data );
 	};
-	const updateCompressionMode = ( value ) => {
-		setCanSave( true );
-		const data = { ...settings };
-		data.compression_mode = value;
-		setSettings( data );
-	};
+
 	const getCompressionRatio = () => {
 		if ( sampleImages.optimized_size > sampleImages.original_size ) {
 			return Math.floor( Math.random() * 60 ) + 10;
@@ -141,7 +136,7 @@ const Compression = ({
 			//If user already changed those before, we need to save them so if he switch back to custom, we can use the old settings
 			saveCustomSettings();
 		}
-
+		setCanSave( true );
 		const data = { ...settings };
 		if ( 'speed_optimized' === value ) {
 			data[ 'best_format' ] = 'disabled';
@@ -165,9 +160,8 @@ const Compression = ({
 			data.avif = ( customSettings.avif ?? isAVIFEnabled ) ? 'enabled' : 'disabled';
 			data[ 'strip_metadata' ] = ( customSettings.strip_metadata ?? isStripMetadataEnabled ) ? 'enabled' : 'disabled';
 		}
+		data.compression_mode = value;
 		setSettings( data );
-		updateCompressionMode( value );
-
 	};
 	return (
 		<>

--- a/assets/src/dashboard/style.scss
+++ b/assets/src/dashboard/style.scss
@@ -73,7 +73,18 @@ $mango-yellow: #FBBF24;
 			}
 		}
 	}
-
+	.components-toggle-group-control-option-base{
+	  	color: var(--wp-components-color-foreground);
+		&[aria-checked="true"]{
+			color:white;
+		}
+		+ div > div{
+			background: var(--wp-components-color-foreground);
+		}
+	} 
+	.components-toggle-group-control{
+		border-color: var(--wp-components-color-foreground);
+	}
 	.base-control-label {
 		color: #363636;
 		display: block;
@@ -440,6 +451,7 @@ $mango-yellow: #FBBF24;
 			margin-left: -14px;
 		}
 	}
+
 }
 
 .om-notice {

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1749,6 +1749,14 @@ The root cause might be either a security plugin which blocks this feature or so
 				'metricsSubtitle4' => __( 'During last month', 'optimole-wp' ),
 			],
 			'options_strings'                => [
+				'compression_mode'               => __( 'Compression Mode', 'optimole-wp' ),
+				'compression_mode_speed_optimized'                => __( 'Speed Optimized', 'optimole-wp' ),
+				'compression_mode_quality_optimized'              => __( 'Quality Optimized', 'optimole-wp' ),
+				'compression_mode_custom'                         => __( 'Custom', 'optimole-wp' ),
+				'compression_mode_speed_optimized_desc'           => __( 'Prioritizes faster loading and smaller image sizes by applying a balanced level of lossy compression. This setting reduces file size significantly without severely degrading visual quality.', 'optimole-wp' ),
+				'compression_mode_quality_optimized_desc'         => __( 'Delivers high-quality images by applying lossless or near-lossless optimization. Ensures images retain their sharpness and details while still benefiting from moderate file size reduction.', 'optimole-wp' ),
+				'compression_mode_custom_desc'                   => __( 'Customize each setting individually for complete control over image compression.', 'optimole-wp' ),
+
 				'best_format_title'                   => __( 'Automatic Best Image Format Selection', 'optimole-wp' ),
 				'best_format_desc'                    => sprintf(
 				/* translators: 1 is the starting anchor tag, 2 is the ending anchor tag */

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -342,6 +342,7 @@ class Optml_Admin {
 		$this->settings->update( 'best_format', 'disabled' );
 		$this->settings->update( 'skip_lazyload_images', '2' );
 		$this->settings->update( 'avif', 'disabled' );
+		$this->settings->update( 'compression_mode', 'speed_optimized' );
 
 		update_option( self::NEW_USER_DEFAULTS_UPDATED, 'yes' );
 	}

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -71,6 +71,7 @@ class Optml_Settings {
 		'resize_smart'               => 'disabled',
 		'no_script'                  => 'disabled',
 		'filters'                    => [],
+		'compression_mode'           => 'custom',
 		'cloud_sites'                => [ 'all' => 'true' ],
 		'watchers'                   => '',
 		'quality'                    => 'auto',
@@ -296,6 +297,9 @@ class Optml_Settings {
 				case 'lazyload_type':
 					$sanitized_value = $this->to_map_values( $value, [ 'fixed', 'viewport', 'all' ], 'fixed' );
 					break;
+				case 'compression_mode':
+					$sanitized_value = $this->to_map_values( $value, [ 'speed_optimized', 'quality_optimized', 'custom' ], 'custom' );
+					break;
 				case 'cloud_sites':
 					$current_sites   = $this->get( 'cloud_sites' );
 					$sanitized_value = array_replace_recursive( $current_sites, $value );
@@ -517,6 +521,7 @@ class Optml_Settings {
 			'resize_smart'               => $this->get( 'resize_smart' ),
 			'no_script'                  => $this->get( 'no_script' ),
 			'lazyload_type'              => $this->get( 'lazyload_type' ),
+			'compression_mode'           => $this->get( 'compression_mode' ),
 			'image_replacer'             => $this->get( 'image_replacer' ),
 			'cdn'                        => $this->get( 'cdn' ),
 			'filters'                    => $this->get_filters(),


### PR DESCRIPTION
- Added a new toggle group control for selecting compression modes: Speed Optimized, Quality Optimized, and Custom.
- Updated the Compression component to handle the new compression mode logic and state management.
- Enhanced the admin settings to include compression mode options and their descriptions.
- Updated styles for the toggle group control to improve UI consistency.

### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
 Adds a compression preset which control individual settings for compression. 
![image](https://github.com/user-attachments/assets/0f988e8a-8760-4da2-b5b4-218399a3cbf9)
https://github.com/Codeinwp/optimole-service/issues/1435#issuecomment-2775527936


### How to test the changes in this Pull Request:

1. Go to Settings -> Compression
2. Change the compression preset

### Other information:

If you previously had custom mode and you switch to sped/optimized and you switch back to custom, the previously values should show up, unless you save the mode. 

