### PR TITLE
Fix/media rename mimetype

### DIFF
--- a/inc/media_rename/attachment_model.php
+++ b/inc/media_rename/attachment_model.php
@@ -75,6 +75,13 @@ class Optml_Attachment_Model {
 	private $is_remote_attachment;
 
 	/**
+	 * The attachment mime type.
+	 *
+	 * @var string
+	 */
+	private $mime_type;
+
+	/**
 	 * The attachment metadata.
 	 *
 	 * @var array
@@ -91,11 +98,9 @@ class Optml_Attachment_Model {
 	public function __construct( int $attachment_id ) {
 		$this->attachment_id = $attachment_id;
 		$this->attachment_metadata = wp_get_attachment_metadata( $this->attachment_id );
+		$this->mime_type = get_post_mime_type( $attachment_id );
 
-		$mime_type = get_post_mime_type( $attachment_id );
-		$is_image = strpos( $mime_type, 'image' ) !== false;
-
-		$this->main_attachment_url          = $is_image ? wp_get_original_image_url( $attachment_id ) : wp_get_attachment_url( $attachment_id );
+		$this->main_attachment_url          = $this->is_image() ? wp_get_original_image_url( $attachment_id ) : wp_get_attachment_url( $attachment_id );
 		$this->origianal_attached_file_path = $this->setup_original_attached_file();
 		$this->dir_path = dirname( $this->origianal_attached_file_path );
 		$this->is_scaled = isset( $this->attachment_metadata['original_image'] );
@@ -285,5 +290,19 @@ class Optml_Attachment_Model {
 	 */
 	public function can_be_renamed_or_replaced() {
 		return ! $this->is_remote_attachment;
+	}
+
+	/**
+	 * Get the attachment mime type.
+	 */
+	public function get_attachment_mimetype() {
+		return $this->mime_type;
+	}
+
+	/**
+	 * Check if the attachment is an image.
+	 */
+	public function is_image() {
+		return strpos( $this->mime_type, 'image' ) !== false;
 	}
 }

--- a/inc/media_rename/attachment_rename.php
+++ b/inc/media_rename/attachment_rename.php
@@ -98,7 +98,9 @@ class Optml_Attachment_Rename {
 		}
 
 		try {
-			$replacer = new Optml_Attachment_Db_Renamer();
+			$skip_sizes = ! $this->attachment->is_image();
+
+			$replacer = new Optml_Attachment_Db_Renamer( $skip_sizes );
 			$old_url = $this->attachment->get_main_url();
 			$new_url = $this->get_new_url( $new_unique_filename );
 
@@ -143,6 +145,12 @@ class Optml_Attachment_Rename {
 
 		if ( ! $attached_update ) {
 			return false;
+		}
+
+		// We should bail for non-image attachments here.
+		// No need for additional metadata update.
+		if ( ! $this->attachment->is_image() ) {
+			return true;
 		}
 
 		// Get current attachment metadata


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 - Fixes issue where non-images renaming was throwing an error even if it actually worked in the background
 

### How to test the changes in this Pull Request:

1. Upload a PDF file, MP4, anything other than an image mimetype;
2. Rename it - it should not throw an error;

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
