### PR TITLE
fix: fatal error thrown because get_current_screen function is not loaded

### DIFF
--- a/inc/media_rename/attachment_edit.php
+++ b/inc/media_rename/attachment_edit.php
@@ -85,6 +85,10 @@ class Optml_Attachment_Edit {
 	 * @return array Modified form fields.
 	 */
 	public function add_attachment_fields( $form_fields, $post ) {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return $form_fields;
+		}
+
 		$screen = get_current_screen();
 
 		$attachment = new Optml_Attachment_Model( $post->ID );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 - Checks that `get_current_screen` function is loaded before hooking into the attachment fields for the rename / replace fields;

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
