### PR TITLE
Style: Update dashboard colors and dependencies

### DIFF
--- a/assets/src/dashboard/style.scss
+++ b/assets/src/dashboard/style.scss
@@ -6,8 +6,9 @@ $primary: #EF686B;
 $success: #5F9D61;
 $danger: #E77777;
 $warning: #ffebeb;
+$purple: #8b5cf6;
 $info: #577BF9;
-$light-blue: #EEF2FE;
+$light-blue: #F5F7FC;
 $dark-blue: #3557A6;
 $purple-gray: #757296;
 $grayish-blue: #f6f6fa;
@@ -328,19 +329,19 @@ $mango-yellow: #FBBF24;
 		}
 
 		&.is-secondary {
-			color: #fff;
+			color: #4d4c4c;
 			border: none;
 			box-shadow: none;
-			background-color: $purple-gray;
+			background-color: #e9e9f6;
 
 			&:hover:not(:disabled),
 			&:active:not(:disabled) {
-				color: #fff;
-				background-color: $purple-gray;
+				color: #4d4c4c;
+				background-color: #e9e9f6;
 			}
 
 			&:focus:not(:disabled) {
-				box-shadow: inset 0 0 0 1px var(--wp-components-color-background,#fff),0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent,var(--wp-admin-theme-color,#007cba));
+				box-shadow: inset 0 0 0 1px var(--wp-components-color-background,#fff),0 0 0 var(--wp-admin-border-width-focus) #4d4c4c;
 			}
 		}
 

--- a/assets/src/dashboard/style.scss
+++ b/assets/src/dashboard/style.scss
@@ -6,11 +6,10 @@ $primary: #EF686B;
 $success: #5F9D61;
 $danger: #E77777;
 $warning: #ffebeb;
-$purple: #8b5cf6;
 $info: #577BF9;
 $light-blue: #F5F7FC;
 $dark-blue: #3557A6;
-$purple-gray: #757296;
+$purple-gray: #e9e9f6;
 $grayish-blue: #f6f6fa;
 $disabled: #6786F4;
 $mango-yellow: #FBBF24;
@@ -332,12 +331,12 @@ $mango-yellow: #FBBF24;
 			color: #4d4c4c;
 			border: none;
 			box-shadow: none;
-			background-color: #e9e9f6;
+			background-color: $purple-gray;
 
 			&:hover:not(:disabled),
 			&:active:not(:disabled) {
 				color: #4d4c4c;
-				background-color: #e9e9f6;
+				background-color: $purple-gray;
 			}
 
 			&:focus:not(:disabled) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "optimole-wp",
-      "version": "3.14.1",
+      "version": "4.0.3",
       "license": "GPL-2.0+",
       "dependencies": {
         "classnames": "^2.3.2",


### PR DESCRIPTION
the original issue didn't had a accurate mockup, using the style of the plugin and the expected improvements, ended up not being present. 

this commit aims to pick a lighter color for the bg + a lighter secondary button color since the "i already have an account" would be used in a very very few cases.

<img width="1260" alt="Screenshot 2025-05-01 at 10 48 23" src="https://github.com/user-attachments/assets/a57164c0-9a1c-403d-961e-fc26be9e57c5" />
<img width="1294" alt="Screenshot 2025-05-01 at 10 48 20" src="https://github.com/user-attachments/assets/e33838e3-7482-4aa0-ab8c-fb295e3d0a2b" />

