### PR TITLE
Fixed optimisation sidebar status when account is disabled

### DIFF
--- a/assets/src/dashboard/parts/connected/OptimizationStatus.js
+++ b/assets/src/dashboard/parts/connected/OptimizationStatus.js
@@ -2,9 +2,15 @@ import { Icon } from '@wordpress/components';
 import { closeSmall, check } from '@wordpress/icons';
 
 const OptimizationStatus = ({ settings }) => {
-	const lazyloadEnabled = 'enabled' === settings?.lazyload;
-	const imageHandlingEnabled = 'enabled' === settings?.image_replacer;
+	const userStatus = optimoleDashboardApp.user_status ? optimoleDashboardApp.user_status : 'inactive';
+	const lazyloadEnabled = 'enabled' === settings?.lazyload  &&  'inactive' !== userStatus;
+	const imageHandlingEnabled = 'enabled' === settings?.image_replacer && 'inactive' !== userStatus;
 	const statuses = [
+		{
+			active: 'inactive' !== userStatus,
+			label: optimoleDashboardApp.strings.optimization_status.statusTitle4,
+			description: optimoleDashboardApp.strings.optimization_status.statusSubTitle4
+		},
 		{
 			active: imageHandlingEnabled,
 			label: optimoleDashboardApp.strings.optimization_status.statusTitle1,

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -2136,6 +2136,8 @@ The root cause might be either a security plugin which blocks this feature or so
 				'statusSubTitle2' => __( 'Images load as visitors scroll', 'optimole-wp' ),
 				'statusTitle3'    => __( 'Image Scalling', 'optimole-wp' ),
 				'statusSubTitle3' => __( 'All images are perfectly sized for devices', 'optimole-wp' ),
+				'statusTitle4'    => __( 'Account Status', 'optimole-wp' ),
+				'statusSubTitle4' => __( 'Your optimole account status', 'optimole-wp' ),
 			],
 			'optimization_tips'              => sprintf(
 			/* translators: 1 is the opening anchor tag, 2 is the closing anchor tag */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
 - Updated the status display logic and add a account active check.

Closes https://github.com/Codeinwp/optimole-wp/issues/943

### How to test the changes in this Pull Request:

1. Check the status of your suspended account in your site
2. The sidebar will show the status based on the account status.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
