### PR TITLE
Fix/compats

### DIFF
--- a/inc/compatibilities/beaver_builder.php
+++ b/inc/compatibilities/beaver_builder.php
@@ -32,7 +32,18 @@ class Optml_beaver_builder extends Optml_compatibility {
 				return $all_watchers;
 			}
 		);
-		add_filter( 'fl_builder_render_css', [ Optml_Main::instance()->manager, 'replace_content' ], PHP_INT_MAX, 1 );
-		add_filter( 'fl_builder_render_js', [ Optml_Main::instance()->manager, 'replace_content' ], PHP_INT_MAX, 1 );
+		add_filter( 'fl_builder_render_css', [ $this, 'replace_static_content' ], PHP_INT_MAX, 1 );
+		add_filter( 'fl_builder_render_js', [ $this, 'replace_static_content' ], PHP_INT_MAX, 1 );
+	}
+
+	/**
+	 * Replace urls in static content.
+	 *
+	 * @param string $content Content to replace.
+	 *
+	 * @return string Altered content.
+	 */
+	public function replace_static_content( $content ) {
+		return Optml_Main::instance()->manager->replace_content( $content, true );
 	}
 }

--- a/inc/compatibilities/divi_builder.php
+++ b/inc/compatibilities/divi_builder.php
@@ -56,7 +56,7 @@ class Optml_divi_builder extends Optml_compatibility {
 				$data = $page_resource->get_data( 'file' );
 
 				if ( ! empty( $data ) ) {
-					$data = Optml_Main::instance()->manager->replace_content( $data );
+					$data = Optml_Main::instance()->manager->replace_content( $data, true );
 					ET_Core_PageResource::$wpfs->put_contents( $page_resource->path, $data, 0644 );
 				}
 			}

--- a/inc/compatibilities/elementor_builder_late.php
+++ b/inc/compatibilities/elementor_builder_late.php
@@ -48,7 +48,7 @@ class Optml_elementor_builder_late extends Optml_compatibility {
 				return $metadata;
 			}
 
-			return Optml_Main::instance()->manager->replace_content( $current_meta );
+			return Optml_Main::instance()->manager->replace_content( $current_meta, true );
 		}
 
 		// Return original if the check does not pass

--- a/inc/compatibilities/facetwp.php
+++ b/inc/compatibilities/facetwp.php
@@ -39,7 +39,7 @@ class Optml_facetwp extends Optml_compatibility {
 		$output = json_decode( $output );
 
 		if ( isset( $output->template ) ) {
-			$output->template = Optml_Main::instance()->manager->replace_content( $output->template );
+			$output->template = Optml_Main::instance()->manager->replace_content( $output->template, true );
 		}
 
 		// Ignore invalid UTF-8 characters in PHP 7.2+
@@ -48,7 +48,7 @@ class Optml_facetwp extends Optml_compatibility {
 		} else {
 			$output = json_encode( $output, JSON_INVALID_UTF8_IGNORE );
 		}
-		$output = Optml_Main::instance()->manager->replace_content( $output );
+		$output = Optml_Main::instance()->manager->replace_content( $output, true );
 		return $output;
 	}
 	/**
@@ -65,7 +65,7 @@ class Optml_facetwp extends Optml_compatibility {
 		if ( ! isset( $output['template'] ) || ! function_exists( 'FWP' ) ) {
 			return;
 		}
-		$output['template'] = Optml_Main::instance()->manager->replace_content( $output['template'] );
+		$output['template'] = Optml_Main::instance()->manager->replace_content( $output['template'], true );
 		FWP()->request->output = $output;
 	}
 	/**

--- a/inc/compatibilities/yith_quick_view.php
+++ b/inc/compatibilities/yith_quick_view.php
@@ -23,7 +23,12 @@ class Optml_yith_quick_view extends Optml_compatibility {
 	 */
 	public function register() {
 		Optml_Url_Replacer::instance()->init();
-		add_filter( 'woocommerce_single_product_image_thumbnail_html', [ Optml_Main::instance()->manager, 'replace_content' ] );
+		add_filter(
+			'woocommerce_single_product_image_thumbnail_html',
+			function ( $html ) {
+				return Optml_Main::instance()->manager->replace_content( $html, true );
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
Introduce a new option for partial content replacement, for compatibilities where we replace just the css, js or pieces of content and not the full page. 

On full page we do more optimizations like viewport detection which is not needed in those contexts. 