### PR TITLE
fix: add compatibility with JetPack

### DIFF
--- a/inc/compatibilities/jetpack.php
+++ b/inc/compatibilities/jetpack.php
@@ -27,8 +27,6 @@ class Optml_jetpack extends Optml_compatibility {
 		add_filter(
 			'jetpack_sync_before_send_jetpack_published_post',
 			function ( $data ) {
-				Optml_Url_Replacer::instance()->init();
-
 				if ( is_array( $data ) ) {
 					foreach ( $data as $key => &$value ) {
 						if ( $value instanceof \WP_Post ) {
@@ -43,8 +41,6 @@ class Optml_jetpack extends Optml_compatibility {
 							if ( isset( $value->featured_image ) && ! empty( $value->featured_image ) ) {
 								$value->featured_image = apply_filters( 'optml_content_url', $value->featured_image );
 							}
-
-							$data[ $key ] = $value;
 						}
 					}
 				}

--- a/inc/compatibilities/jetpack.php
+++ b/inc/compatibilities/jetpack.php
@@ -27,21 +27,25 @@ class Optml_jetpack extends Optml_compatibility {
 		add_filter(
 			'jetpack_sync_before_send_jetpack_published_post',
 			function ( $data ) {
-				if ( is_array( $data ) ) {
-					foreach ( $data as $key => &$value ) {
-						if ( $value instanceof \WP_Post ) {
-							if ( ! empty( $value->post_content ) ) {
-								$value->post_content = Optml_Main::instance()->manager->replace_content( $value->post_content );
-							}
+				if ( ! is_array( $data ) ) {
+					return $data;
+				}
 
-							if ( ! empty( $value->post_excerpt ) ) {
-								$value->post_excerpt = Optml_Main::instance()->manager->replace_content( $value->post_excerpt );
-							}
+				foreach ( $data as &$value ) {
+					if ( ! $value instanceof \WP_Post ) {
+						continue;
+					}
 
-							if ( isset( $value->featured_image ) && ! empty( $value->featured_image ) ) {
-								$value->featured_image = apply_filters( 'optml_content_url', $value->featured_image );
-							}
-						}
+					if ( ! empty( $value->post_content ) ) {
+						$value->post_content = Optml_Main::instance()->manager->replace_content( $value->post_content );
+					}
+
+					if ( ! empty( $value->post_excerpt ) ) {
+						$value->post_excerpt = Optml_Main::instance()->manager->replace_content( $value->post_excerpt );
+					}
+
+					if ( isset( $value->featured_image ) && ! empty( $value->featured_image ) ) {
+						$value->featured_image = apply_filters( 'optml_content_url', $value->featured_image );
 					}
 				}
 

--- a/inc/compatibilities/jetpack.php
+++ b/inc/compatibilities/jetpack.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Class Optml_jetengine
+ *
+ * @reason Add support for JetEngine plugin custom endpoints.
+ */
+class Optml_jetpack extends Optml_compatibility {
+
+	/**
+	 * Should we load the integration logic.
+	 *
+	 * @return bool Should we load.
+	 */
+	public function should_load() {
+		include_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		return is_plugin_active( 'jetpack/jetpack.php' );
+	}
+
+    /**
+     * Register integration details.
+     *
+     * @return void
+     */
+    public function register() {
+    	add_filter(
+    		'jetpack_sync_before_send_jetpack_published_post',
+    		function ( $data ) {
+    		    Optml_Url_Replacer::instance()->init();
+    			
+    			if ( is_array( $data ) ) {
+    				foreach ( $data as $key => &$value ) {
+    					if ( $value instanceof \WP_Post ) {
+    						if ( ! empty( $value->post_content ) ) {
+    							$value->post_content = Optml_Main::instance()->manager->replace_content( $value->post_content );
+    						}
+    						
+    						if ( ! empty( $value->post_excerpt ) ) {
+    							$value->post_excerpt = Optml_Main::instance()->manager->replace_content( $value->post_excerpt );
+    						}
+    						
+    						if ( isset( $value->featured_image ) && ! empty( $value->featured_image ) ) {
+    							$value->featured_image = apply_filters( 'optml_content_url', $value->featured_image );
+    						}
+    						
+    						$data[ $key ] = $value;
+    					}
+    				}
+    			}
+    			
+    			return $data;
+    		},
+    		10
+    	);
+    }
+
+	/**
+	 * Should we early load the compatibility?
+	 *
+	 * @return bool Whether to load the compatibility or not.
+	 */
+	public function should_load_early() {
+		return true;
+	}
+}

--- a/inc/compatibilities/jetpack.php
+++ b/inc/compatibilities/jetpack.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Class Optml_jetengine
+ * Class Optml_jetpack
  *
- * @reason Add support for JetEngine plugin custom endpoints.
+ * @reason Add support for Jetpack plugin custom endpoints.
  */
 class Optml_jetpack extends Optml_compatibility {
 

--- a/inc/compatibilities/jetpack.php
+++ b/inc/compatibilities/jetpack.php
@@ -18,42 +18,42 @@ class Optml_jetpack extends Optml_compatibility {
 		return is_plugin_active( 'jetpack/jetpack.php' );
 	}
 
-    /**
-     * Register integration details.
-     *
-     * @return void
-     */
-    public function register() {
-    	add_filter(
-    		'jetpack_sync_before_send_jetpack_published_post',
-    		function ( $data ) {
-    		    Optml_Url_Replacer::instance()->init();
-    			
-    			if ( is_array( $data ) ) {
-    				foreach ( $data as $key => &$value ) {
-    					if ( $value instanceof \WP_Post ) {
-    						if ( ! empty( $value->post_content ) ) {
-    							$value->post_content = Optml_Main::instance()->manager->replace_content( $value->post_content );
-    						}
-    						
-    						if ( ! empty( $value->post_excerpt ) ) {
-    							$value->post_excerpt = Optml_Main::instance()->manager->replace_content( $value->post_excerpt );
-    						}
-    						
-    						if ( isset( $value->featured_image ) && ! empty( $value->featured_image ) ) {
-    							$value->featured_image = apply_filters( 'optml_content_url', $value->featured_image );
-    						}
-    						
-    						$data[ $key ] = $value;
-    					}
-    				}
-    			}
-    			
-    			return $data;
-    		},
-    		10
-    	);
-    }
+	/**
+	 * Register integration details.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		add_filter(
+			'jetpack_sync_before_send_jetpack_published_post',
+			function ( $data ) {
+				Optml_Url_Replacer::instance()->init();
+
+				if ( is_array( $data ) ) {
+					foreach ( $data as $key => &$value ) {
+						if ( $value instanceof \WP_Post ) {
+							if ( ! empty( $value->post_content ) ) {
+								$value->post_content = Optml_Main::instance()->manager->replace_content( $value->post_content );
+							}
+
+							if ( ! empty( $value->post_excerpt ) ) {
+								$value->post_excerpt = Optml_Main::instance()->manager->replace_content( $value->post_excerpt );
+							}
+
+							if ( isset( $value->featured_image ) && ! empty( $value->featured_image ) ) {
+								$value->featured_image = apply_filters( 'optml_content_url', $value->featured_image );
+							}
+
+							$data[ $key ] = $value;
+						}
+					}
+				}
+
+				return $data;
+			},
+			10
+		);
+	}
 
 	/**
 	 * Should we early load the compatibility?

--- a/inc/manager.php
+++ b/inc/manager.php
@@ -100,6 +100,7 @@ final class Optml_Manager {
 		'otter_blocks',
 		'spectra',
 		'wpsp',
+		'jetpack',
 	];
 	/**
 	 * The current state of the buffer.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request

When JetPack performs the synchronization, it pulls the WP_Posts without Optimole applied. The compatibility modifies the contents of the payload so that the content and the featured image include Optimole optimizations.

#### WordPress Reader
<img width="4038" height="1150" alt="CleanShot 2025-09-12 at 15 03 15@2x" src="https://github.com/user-attachments/assets/47d0be62-2028-45d8-a9ea-31ae947413a4" />

```css
background-image: url(&quot;https://i0.wp.com/mlhgoovhyl5g.i.optimole.com/w:auto/h:auto/q:mauto/ig:avif/https://robert-optimole-test.instawp.co/wp-content/uploads/2025/09/167113836-efdbde32-7863-4a24-9d2d-979025b51260.jpeg?quality=80&ssl=1&strip=info&w=1200&quot;); background-size: cover; background-repeat: no-repeat; background-position: center center;
```

####  Gmail
<img width="3864" height="1794" alt="CleanShot 2025-09-12 at 15 06 07@2x" src="https://github.com/user-attachments/assets/c08402d9-1a00-4a1c-9356-1bbcf3714724" />

When received by Google, they switch our CDN with theirs, but the origin is Optimole.
```css
src="https://ci3.googleusercontent.com/meips/ADKq_NZC7WDiAynJxsi287Z8tYysdNP_dn6X2MyCrQstkwS67N_tzKyN5o-EUKYzujjqfjJCTHsvHL1ebLavpYSztH8IsGEsH0gJcpsxUzAQODtUpPMM-4XE5V8c5ckuqFrPPXEFPg5tvi3feOx1DAp8Sx5-sgMfxXmIxuyVRTDX6JMTJYXktQassKNtSP4kPKhEV85R=s0-d-e1-ft#https://robert-optimole-test.instawp.co/wp-content/uploads/2025/09/167113836-efdbde32-7863-4a24-9d2d-979025b51260.jpeg?w=504"
```


Closes https://github.com/Codeinwp/optimole-service/issues/1570
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
