### PR TITLE
fix: fetch the image samples for quality on effect event

### DIFF
--- a/assets/src/dashboard/parts/connected/settings/Compression.js
+++ b/assets/src/dashboard/parts/connected/settings/Compression.js
@@ -22,6 +22,7 @@ import {
 } from '@wordpress/components';
 
 import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -46,7 +47,6 @@ const Compression = ({
 			getSampleRate,
 			isLoading
 		} = select( 'optimole' );
-
 		return {
 			sampleImages: getSampleRate(),
 			isLoading: isLoading()
@@ -167,6 +167,13 @@ const Compression = ({
 		data.compression_mode = value;
 		setSettings( data );
 	};
+
+	useEffect( () => {
+		if ( showSample ) {
+			loadSample();
+		}
+	}, [ showSample ]);
+
 	return (
 		<>
 

--- a/assets/src/dashboard/parts/connected/settings/index.js
+++ b/assets/src/dashboard/parts/connected/settings/index.js
@@ -10,7 +10,7 @@ import Lazyload from './Lazyload';
 import Exclusions from './Exclusions';
 import OffloadMedia from './OffloadMedia';
 import CloudLibrary from './CloudLibrary';
-import { sampleRate, saveSettings } from '../../../utils/api';
+import { saveSettings } from '../../../utils/api';
 import { toggleDamSidebarLink } from '../../../utils/helpers';
 
 const Settings = ({
@@ -59,18 +59,7 @@ const Settings = ({
 		localStorage.setItem( 'optimole_settings_visits', visits ? parseInt( visits ) + 1 : 1 );
 	}, [ tab ]);
 
-	const loadSample = () => {
-		if ( ! showSample ) {
-			setIsSampleLoading( true );
-
-			sampleRate(
-				{
-					quality: settings.quality
-				},
-				() => setIsSampleLoading( false )
-			);
-		}
-
+	const toggleShowSample = () => {
 		setShowSample( ! showSample );
 	};
 
@@ -165,7 +154,7 @@ const Settings = ({
 						<Button
 							variant="default"
 							disabled={ isLoading }
-							onClick={ loadSample }
+							onClick={ toggleShowSample }
 						>
 							{ optimoleDashboardApp.strings.options_strings.view_sample_image }
 						</Button>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

Moved the image sample loading inside the `Compression` component. When using in `Compression`, the loading will behave like the refresh button, which requests the optimized images with the `force=true` parameter that prevents the cache.

Closes https://github.com/Codeinwp/optimole-service/issues/1512

### How to test the changes in this Pull Request:

1. Go to Advanced > Compression and choose `Custom`
2. Disable `Auto Quality Powered by ML(Machine Learning)`
3. Press on `View sample image`
4. Check the displayed data

https://github.com/user-attachments/assets/47dd3356-dc71-4e00-bb1e-a781f2f39159


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
