### PR TITLE
refactor: dashboard optimization status

### DIFF
--- a/assets/src/dashboard/parts/connected/OptimizationStatus.js
+++ b/assets/src/dashboard/parts/connected/OptimizationStatus.js
@@ -49,35 +49,33 @@ const OptimizationStatus = ({ settings, setSettings, setCanSave, setTab }) => {
 		}
 	};
 
+	const {
+		optimization_status
+	} = optimoleDashboardApp.strings;
 
 	const statuses = [
 		{
+			settingType: 'image_replacer',
 			active: imageHandlingEnabled,
-			label: optimoleDashboardApp.strings.optimization_status.statusTitle1,
-			description: optimoleDashboardApp.strings.optimization_status.statusSubTitle1,
-			buttonText: imageHandlingEnabled ? optimoleDashboardApp.strings.optimization_status.manage : optimoleDashboardApp.strings.optimization_status.enable,
-			settingType: 'image_replacer'
+			label: optimization_status.statusTitle1,
+			description: optimization_status.statusSubTitle1,
+			buttonText: imageHandlingEnabled ? optimization_status.manage : optimization_status.enable
 		},
 		{
-			active: lazyloadEnabled,
-			label: optimoleDashboardApp.strings.optimization_status.statusTitle2,
-			description: optimoleDashboardApp.strings.optimization_status.statusSubTitle2,
-			buttonText: lazyloadEnabled ? optimoleDashboardApp.strings.optimization_status.disable : optimoleDashboardApp.strings.optimization_status.enable,
-			settingType: 'lazyload'
+			settingType: 'lazyload',
+			active: lazyloadEnabled && imageHandlingEnabled,
+			label: optimization_status.statusTitle2,
+			description: optimization_status.statusSubTitle2,
+			buttonText: imageHandlingEnabled ? ( lazyloadEnabled ? optimization_status.disable : optimization_status.enable ) : ''
 		},
 		{
-			active: lazyloadEnabled && 'disabled' === settings?.scale,
-			label: optimoleDashboardApp.strings.optimization_status.statusTitle3,
-			description: optimoleDashboardApp.strings.optimization_status.statusSubTitle3,
-			buttonText: ( lazyloadEnabled && 'disabled' === settings?.scale ) ? optimoleDashboardApp.strings.optimization_status.disable : optimoleDashboardApp.strings.optimization_status.enable,
-			settingType: 'scale'
+			settingType: 'scale',
+			active: ( lazyloadEnabled && 'disabled' === settings?.scale ) && imageHandlingEnabled,
+			label: optimization_status.statusTitle3,
+			description: optimization_status.statusSubTitle3,
+			buttonText: imageHandlingEnabled ? ( ( lazyloadEnabled && 'disabled' === settings?.scale ) ? optimization_status.disable : optimization_status.enable ) : ''
 		}
-	].map( el => ({
-		...el, active: imageHandlingEnabled && el.active,
-		buttonText: 'image_replacer' === el.settingType ?
-			( imageHandlingEnabled ? el.buttonText : optimoleDashboardApp.strings.optimization_status.enable ) :
-			( imageHandlingEnabled ? el.buttonText : optimoleDashboardApp.strings.optimization_status.block )
-	}) );
+	];
 
 	return (
 		<div className="bg-white flex flex-col text-gray-700 border-0 rounded-lg shadow-md p-8">
@@ -95,7 +93,7 @@ const OptimizationStatus = ({ settings, setSettings, setCanSave, setTab }) => {
 								<Icon icon={closeSmall} className="fill-danger bg-danger/20 rounded-full" size={20} />
 							)}
 							<div>
-								<span className='text-gray-700 font-normal font-semibold'>
+								<span className='text-gray-700 font-semibold'>
 									{status.label}
 								</span>
 								<p className="m-0">{status.description}</p>

--- a/assets/src/dashboard/parts/connected/OptimizationStatus.js
+++ b/assets/src/dashboard/parts/connected/OptimizationStatus.js
@@ -12,9 +12,9 @@ const OptimizationStatus = ({ settings, setSettings, setCanSave, setTab }) => {
 		};
 	}, []);
 
-	const userStatus = optimoleDashboardApp.user_status ? optimoleDashboardApp.user_status : 'inactive';
-	const lazyloadEnabled = 'enabled' === settings?.lazyload && 'active' === userStatus;
-	const imageHandlingEnabled = 'enabled' === settings?.image_replacer && 'active' === userStatus;
+	const lazyloadEnabled = 'enabled' === settings?.lazyload;
+	const imageHandlingEnabled = 'enabled' === settings?.image_replacer;
+
 	const directUpdate = ( option, value ) => {
 		if ( setCanSave && setSettings ) {
 			setCanSave( true );

--- a/assets/src/dashboard/parts/connected/Sidebar.js
+++ b/assets/src/dashboard/parts/connected/Sidebar.js
@@ -23,7 +23,7 @@ const reasons = [
 	optimoleDashboardApp.strings.upgrade.reason_4
 ];
 
-const Sidebar = ({ settings }) => {
+const Sidebar = ({ settings, setSettings, setCanSave, setTab }) => {
 	const {
 		name,
 		domain,
@@ -121,7 +121,12 @@ const Sidebar = ({ settings }) => {
 				</Button>
 			) }
 
-			<OptimizationStatus settings={settings} />
+			<OptimizationStatus
+				settings={settings}
+				setSettings={setSettings}
+				setCanSave={setCanSave}
+				setTab={setTab}
+			/>
 
 			{ showSPCRecommendation && (
 				<SPCRecommendation />

--- a/assets/src/dashboard/parts/connected/index.js
+++ b/assets/src/dashboard/parts/connected/index.js
@@ -121,7 +121,12 @@ const ConnectedLayout = ({
 					{ 'help' === tab && <Help /> }
 				</div>
 
-				<Sidebar settings={settings}/>
+				<Sidebar
+					settings={settings}
+					setSettings={setSettings}
+					setCanSave={setCanSave}
+					setTab={setTab}
+				/>
 			</div>
 		</div>
 	);

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -2192,6 +2192,10 @@ The root cause might be either a security plugin which blocks this feature or so
 				'statusSubTitle2' => __( 'Images load as visitors scroll', 'optimole-wp' ),
 				'statusTitle3'    => __( 'Image Scalling', 'optimole-wp' ),
 				'statusSubTitle3' => __( 'All images are perfectly sized for devices', 'optimole-wp' ),
+				'disable'         => __( 'Disable', 'optimole-wp' ),
+				'enable'          => __( 'Enable', 'optimole-wp' ),
+				'manage'          => __( 'Manage', 'optimole-wp' ),
+				'block'           => __( 'Block', 'optimole-wp' ),
 			],
 			'optimization_tips'              => sprintf(
 			/* translators: 1 is the opening anchor tag, 2 is the closing anchor tag */

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -2195,7 +2195,6 @@ The root cause might be either a security plugin which blocks this feature or so
 				'disable'         => __( 'Disable', 'optimole-wp' ),
 				'enable'          => __( 'Enable', 'optimole-wp' ),
 				'manage'          => __( 'Manage', 'optimole-wp' ),
-				'block'           => __( 'Block', 'optimole-wp' ),
 			],
 			'optimization_tips'              => sprintf(
 			/* translators: 1 is the opening anchor tag, 2 is the closing anchor tag */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
The user can now interact with the optimization status dashboard using:
- Image Handling: Redirects to the settings page/enables the setting.
- Smart Lazy-Loading, Image Scaling: Programmatically disable/enable from status.

Closes https://github.com/Codeinwp/optimole-service/issues/1490

### Testing

- If image handling is disabled, Lazy & Scaling are also disabled, along with the hidden button.
- Scaling depends on Lazy; if Scaling is enabled but you disable Lazy, Scaling will also be disabled.
- If Lazy is disabled, when enabling, it will not modify the Scaling.

https://github.com/user-attachments/assets/8eae435c-125e-4016-826e-8cd4c34d376c

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
