### PR TITLE
feat: increase the visibility of rename/replace

### DIFF
--- a/assets/js/modal-attachment.js
+++ b/assets/js/modal-attachment.js
@@ -3,96 +3,64 @@ jQuery(document).ready(function($) {
         return;
     }
 
-    var originalAttachmentDetails = wp.media.view.Attachment.Details;
-    
-    wp.media.view.Attachment.Details = originalAttachmentDetails.extend({
-        initialize: function() {
-            originalAttachmentDetails.prototype.initialize.apply(this, arguments);
-        },
+    /**
+     * Helper function to add Replace or Rename button to attachment actions
+     * @param {Object} view - The attachment view instance
+     */
+    function addReplaceRenameButton(view) {
+        var $el = view.$el;
+        var $actions = $el.find('.actions');
         
-        render: function() {
-            originalAttachmentDetails.prototype.render.apply(this, arguments);
-            
-            this.addReplaceRenameButton();
-            
-            return this;
-        },
-        
-        addReplaceRenameButton: function() {
-            var self = this;
-            
-            var $el = self.$el;
-            var $actions = $el.find('.actions');
-            
-            if ($actions.find('.optml-replace-rename-link').length) {
-                return;
-            }
-            
-            var attachmentId = self.model.get('id');
-            
-            if (attachmentId && $actions.length) {
-                var editUrl = OptimoleModalAttachment.editPostURL + '?post=' + attachmentId + 
-                             '&action=edit&TB_iframe=true&width=90%&height=90%';
-                
-                var $editLink = $actions.find('a[href*="post.php"]');
-                
-                if ($editLink.length) {
-                    $editLink.after(
-                        ' <span class="links-separator">|</span>' +
-                        '<a href="' + editUrl + '" class="optml-replace-rename-link thickbox" title="' + 
-                        OptimoleModalAttachment.i18n.replaceOrRename + '"> ' +
-                        OptimoleModalAttachment.i18n.replaceOrRename + '</a>'
-                    );
-                }
-            }
+        if (!$actions.length || $actions.find('.optml-replace-rename-link').length) {
+            return;
         }
-    });
-    
-    if (wp.media.view.Attachment.Details.TwoColumn) {
-        var originalTwoColumn = wp.media.view.Attachment.Details.TwoColumn;
         
-        wp.media.view.Attachment.Details.TwoColumn = originalTwoColumn.extend({
+        var attachmentId = view.model.get('id');
+        
+        if (!attachmentId) {
+            return;
+        }
+        
+        var editUrl = OptimoleModalAttachment.editPostURL + '?post=' + attachmentId + 
+                     '&action=edit&TB_iframe=true&width=90%&height=90%';
+        
+        var $editLink = $actions.find('a[href*="post.php"]');
+        
+        if ($editLink.length) {
+            $editLink.after(
+                ' <span class="links-separator">|</span>' +
+                '<a href="' + editUrl + '" class="optml-replace-rename-link thickbox" title="' + 
+                OptimoleModalAttachment.i18n.replaceOrRename + '"> ' +
+                OptimoleModalAttachment.i18n.replaceOrRename + '</a>'
+            );
+        }
+    }
+
+    /**
+     * Extend a WordPress media view with Replace/Rename functionality
+     * @param {Object} OriginalView - The original view to extend
+     * @returns {Object} Extended view
+     */
+    function extendMediaView(OriginalView) {
+        return OriginalView.extend({
             initialize: function() {
-                originalTwoColumn.prototype.initialize.apply(this, arguments);
+                OriginalView.prototype.initialize.apply(this, arguments);
             },
             
             render: function() {
-                originalTwoColumn.prototype.render.apply(this, arguments);
-                
-                this.addReplaceRenameButton();
-                
+                OriginalView.prototype.render.apply(this, arguments);
+                addReplaceRenameButton(this);
                 return this;
-            },
-            
-            addReplaceRenameButton: function() {
-                var self = this;
-                
-                var $el = self.$el;
-                var $actions = $el.find('.actions');
-                
-                if ($actions.find('.optml-replace-rename-link').length) {
-                    return;
-                }
-                
-                var attachmentId = self.model.get('id');
-                
-                if (attachmentId && $actions.length) {
-                    var editUrl = OptimoleModalAttachment.editPostURL + '?post=' + attachmentId + 
-                                 '&action=edit&TB_iframe=true&width=90%&height=90%';
-                    
-                    var $editLink = $actions.find('a[href*="post.php"]');
-                    
-                    if ($editLink.length) {
-                        $editLink.after(
-                            ' <span class="links-separator">|</span>' +
-                            '<a href="' + editUrl + '" class="optml-replace-rename-link thickbox" title="' + 
-                            OptimoleModalAttachment.i18n.replaceOrRename + '"> ' +
-                            OptimoleModalAttachment.i18n.replaceOrRename + '</a>'
-                        );
-                    }
-                }
             }
         });
+    }
+
+    var originalAttachmentDetails = wp.media.view.Attachment.Details;
+    wp.media.view.Attachment.Details = extendMediaView(originalAttachmentDetails);
+    
+    if (wp.media.view.Attachment.Details.TwoColumn) {
+        var originalTwoColumn = wp.media.view.Attachment.Details.TwoColumn;
+        wp.media.view.Attachment.Details.TwoColumn = extendMediaView(originalTwoColumn);
     }
     
     $(document).on('click', '.optml-replace-rename-link.thickbox', function() {

--- a/assets/js/modal-attachment.js
+++ b/assets/js/modal-attachment.js
@@ -1,0 +1,101 @@
+jQuery(document).ready(function($) {
+    if (!$('body').hasClass('upload-php')) {
+        return;
+    }
+
+    var originalAttachmentDetails = wp.media.view.Attachment.Details;
+    
+    wp.media.view.Attachment.Details = originalAttachmentDetails.extend({
+        initialize: function() {
+            originalAttachmentDetails.prototype.initialize.apply(this, arguments);
+        },
+        
+        render: function() {
+            originalAttachmentDetails.prototype.render.apply(this, arguments);
+            
+            this.addReplaceRenameButton();
+            
+            return this;
+        },
+        
+        addReplaceRenameButton: function() {
+            var self = this;
+            
+            var $el = self.$el;
+            var $actions = $el.find('.actions');
+            
+            if ($actions.find('.optml-replace-rename-link').length) {
+                return;
+            }
+            
+            var attachmentId = self.model.get('id');
+            
+            if (attachmentId && $actions.length) {
+                var editUrl = OptimoleModalAttachment.editPostURL + '?post=' + attachmentId + 
+                             '&action=edit&TB_iframe=true&width=90%&height=90%';
+                
+                var $editLink = $actions.find('a[href*="post.php"]');
+                
+                if ($editLink.length) {
+                    $editLink.after(
+                        ' <span class="links-separator">|</span>' +
+                        '<a href="' + editUrl + '" class="optml-replace-rename-link thickbox" title="' + 
+                        OptimoleModalAttachment.i18n.replaceOrRename + '"> ' +
+                        OptimoleModalAttachment.i18n.replaceOrRename + '</a>'
+                    );
+                }
+            }
+        }
+    });
+    
+    if (wp.media.view.Attachment.Details.TwoColumn) {
+        var originalTwoColumn = wp.media.view.Attachment.Details.TwoColumn;
+        
+        wp.media.view.Attachment.Details.TwoColumn = originalTwoColumn.extend({
+            initialize: function() {
+                originalTwoColumn.prototype.initialize.apply(this, arguments);
+            },
+            
+            render: function() {
+                originalTwoColumn.prototype.render.apply(this, arguments);
+                
+                this.addReplaceRenameButton();
+                
+                return this;
+            },
+            
+            addReplaceRenameButton: function() {
+                var self = this;
+                
+                var $el = self.$el;
+                var $actions = $el.find('.actions');
+                
+                if ($actions.find('.optml-replace-rename-link').length) {
+                    return;
+                }
+                
+                var attachmentId = self.model.get('id');
+                
+                if (attachmentId && $actions.length) {
+                    var editUrl = OptimoleModalAttachment.editPostURL + '?post=' + attachmentId + 
+                                 '&action=edit&TB_iframe=true&width=90%&height=90%';
+                    
+                    var $editLink = $actions.find('a[href*="post.php"]');
+                    
+                    if ($editLink.length) {
+                        $editLink.after(
+                            ' <span class="links-separator">|</span>' +
+                            '<a href="' + editUrl + '" class="optml-replace-rename-link thickbox" title="' + 
+                            OptimoleModalAttachment.i18n.replaceOrRename + '"> ' +
+                            OptimoleModalAttachment.i18n.replaceOrRename + '</a>'
+                        );
+                    }
+                }
+            }
+        });
+    }
+    
+    $(document).on('click', '.optml-replace-rename-link.thickbox', function() {
+        tb_init('a.thickbox');
+    });
+});

--- a/inc/media_rename/attachment_edit.php
+++ b/inc/media_rename/attachment_edit.php
@@ -30,9 +30,9 @@ class Optml_Attachment_Edit {
 	/**
 	 * Add Replace or Rename action in media library list view.
 	 *
-	 * @param array   $actions The list of actions.
-	 * @param WP_Post $post The post object.
-	 * @return array
+	 * @param string[] $actions Array of row action links.
+	 * @param WP_Post  $post The post object.
+	 * @return string[]
 	 */
 	public function add_replace_rename_action( $actions, $post ) {
 		if ( get_post_type( $post->ID ) !== 'attachment' ) {

--- a/inc/media_rename/attachment_edit.php
+++ b/inc/media_rename/attachment_edit.php
@@ -102,7 +102,7 @@ class Optml_Attachment_Edit {
 		} elseif ( $hook === 'upload.php' ) {
 			wp_enqueue_script(
 				'optml-modal-attachment',
-				OPTML_URL . 'assets/js/modal-attachment.js', // Your JavaScript file
+				OPTML_URL . 'assets/js/modal-attachment.js',
 				[ 'jquery', 'media-views', 'media-models' ],
 				OPTML_VERSION,
 				true

--- a/inc/media_rename/attachment_edit.php
+++ b/inc/media_rename/attachment_edit.php
@@ -24,6 +24,30 @@ class Optml_Attachment_Edit {
 		add_action( 'wp_ajax_optml_replace_file', [ $this, 'replace_file' ] );
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+		add_filter( 'media_row_actions', [ $this, 'add_replace_rename_action' ], 10, 2 );
+	}
+
+	/**
+	 * Add Replace or Rename action in media library list view.
+	 *
+	 * @param array   $actions The list of actions.
+	 * @param WP_Post $post The post object.
+	 * @return array
+	 */
+	public function add_replace_rename_action( $actions, $post ) {
+		if ( get_post_type( $post->ID ) !== 'attachment' ) {
+			return $actions;
+		}
+
+		$edit_url = admin_url( 'post.php?post=' . $post->ID . '&action=edit' );
+		$actions['replace_rename'] = sprintf(
+			'<a href="%s" aria-label="%s">%s</a>',
+			esc_url( $edit_url ),
+			esc_attr__( 'Replace or Rename', 'optimole-wp' ),
+			esc_html__( 'Replace or Rename', 'optimole-wp' )
+		);
+
+		return $actions;
 	}
 
 	/**
@@ -32,48 +56,69 @@ class Optml_Attachment_Edit {
 	 * @param string $hook The hook.
 	 */
 	public function enqueue_scripts( $hook ) {
-		if ( $hook !== 'post.php' ) {
+		if ( $hook !== 'post.php' && $hook !== 'upload.php' ) {
 			return;
 		}
 
-		$id = (int) sanitize_text_field( $_GET['post'] );
+		if ( $hook === 'post.php' ) {
+			$id = (int) sanitize_text_field( $_GET['post'] );
 
-		if ( ! $id ) {
-			return;
+			if ( ! $id ) {
+				return;
+			}
+
+			if ( ! current_user_can( 'edit_post', $id ) ) {
+				return;
+			}
+
+			if ( get_post_type( $id ) !== 'attachment' ) {
+				return;
+			}
+
+			$mime_type = get_post_mime_type( $id );
+
+			$max_file_size = wp_max_upload_size();
+			// translators: %s is the max file size in MB.
+			$max_file_size_error = sprintf( __( 'File size is too large. Max file size is %sMB', 'optimole-wp' ), $max_file_size / 1024 / 1024 );
+
+			wp_enqueue_style( 'optml-attachment-edit', OPTML_URL . 'assets/css/single-attachment.css', [], OPTML_VERSION );
+
+			wp_register_script( 'optml-attachment-edit', OPTML_URL . 'assets/js/single-attachment.js', [ 'jquery' ], OPTML_VERSION, true );
+			wp_localize_script(
+				'optml-attachment-edit',
+				'OMAttachmentEdit',
+				[
+					'ajaxURL'      => admin_url( 'admin-ajax.php' ),
+					'maxFileSize'  => $max_file_size,
+					'attachmentId' => $id,
+					'mimeType'     => $mime_type,
+					'i18n'         => [
+						'maxFileSizeError' => $max_file_size_error,
+						'replaceFileError' => __( 'Error replacing file', 'optimole-wp' ),
+					],
+				]
+			);
+			wp_enqueue_script( 'optml-attachment-edit' );
+		} elseif ( $hook === 'upload.php' ) {
+			wp_enqueue_script(
+				'optml-modal-attachment',
+				OPTML_URL . 'assets/js/modal-attachment.js', // Your JavaScript file
+				[ 'jquery', 'media-views', 'media-models' ],
+				OPTML_VERSION,
+				true
+			);
+
+			wp_localize_script(
+				'optml-modal-attachment',
+				'OptimoleModalAttachment',
+				[
+					'editPostURL' => admin_url( 'post.php' ),
+					'i18n' => [
+						'replaceOrRename' => __( 'Replace or Rename', 'optimole-wp' ),
+					],
+				]
+			);
 		}
-
-		if ( ! current_user_can( 'edit_post', $id ) ) {
-			return;
-		}
-
-		if ( get_post_type( $id ) !== 'attachment' ) {
-			return;
-		}
-
-		$mime_type = get_post_mime_type( $id );
-
-		$max_file_size = wp_max_upload_size();
-		// translators: %s is the max file size in MB.
-		$max_file_size_error = sprintf( __( 'File size is too large. Max file size is %sMB', 'optimole-wp' ), $max_file_size / 1024 / 1024 );
-
-		wp_enqueue_style( 'optml-attachment-edit', OPTML_URL . 'assets/css/single-attachment.css', [], OPTML_VERSION );
-
-		wp_register_script( 'optml-attachment-edit', OPTML_URL . 'assets/js/single-attachment.js', [ 'jquery' ], OPTML_VERSION, true );
-		wp_localize_script(
-			'optml-attachment-edit',
-			'OMAttachmentEdit',
-			[
-				'ajaxURL'      => admin_url( 'admin-ajax.php' ),
-				'maxFileSize'  => $max_file_size,
-				'attachmentId' => $id,
-				'mimeType'     => $mime_type,
-				'i18n'         => [
-					'maxFileSizeError' => $max_file_size_error,
-					'replaceFileError' => __( 'Error replacing file', 'optimole-wp' ),
-				],
-			]
-		);
-		wp_enqueue_script( 'optml-attachment-edit' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
- Added a filter for actions on the media tab to add a redirect to the Rename or Replace edit screen
- Extended the attachment modal to add a redirect to the Rename or Replace edit screen
 
<img width="4982" height="1280" alt="CleanShot 2025-09-29 at 17 10 49@2x" src="https://github.com/user-attachments/assets/739f6068-9bfa-4c78-9e9f-04d312a5cb50" />
<img width="1306" height="178" alt="CleanShot 2025-09-29 at 17 11 04@2x" src="https://github.com/user-attachments/assets/5230e4c4-445e-4455-a1b3-80f5004592d6" />


Closes https://github.com/Codeinwp/optimole-service/issues/1569


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
 
