### PR TITLE
fix: preset settings

### DIFF
--- a/assets/src/dashboard/parts/connected/settings/Compression.js
+++ b/assets/src/dashboard/parts/connected/settings/Compression.js
@@ -174,6 +174,12 @@ const Compression = ({
 		}
 	}, [ showSample ]);
 
+	useEffect( () => {
+		if ( 'speed_optimized' === compressionMode || 'quality_optimized' === compressionMode ) {
+			transformCompressionMode( compressionMode );
+		}
+	}, []);
+
 	return (
 		<>
 

--- a/assets/src/dashboard/parts/connected/settings/Compression.js
+++ b/assets/src/dashboard/parts/connected/settings/Compression.js
@@ -174,12 +174,6 @@ const Compression = ({
 		}
 	}, [ showSample ]);
 
-	useEffect( () => {
-		if ( 'speed_optimized' === compressionMode || 'quality_optimized' === compressionMode ) {
-			transformCompressionMode( compressionMode );
-		}
-	}, []);
-
 	return (
 		<>
 

--- a/assets/src/dashboard/parts/connected/settings/Compression.js
+++ b/assets/src/dashboard/parts/connected/settings/Compression.js
@@ -175,10 +175,10 @@ const Compression = ({
 	}, [ showSample ]);
 
 	useEffect( () => {
-		if ( 'speed_optimized' === compressionMode || 'quality_optimized' === compressionMode ) {
+		if ( 'speed_optimized' === compressionMode ) {
 			transformCompressionMode( compressionMode );
 		}
-	}, []);
+	}, [ compressionMode, transformCompressionMode ]);
 
 	return (
 		<>

--- a/assets/src/dashboard/parts/connected/settings/Compression.js
+++ b/assets/src/dashboard/parts/connected/settings/Compression.js
@@ -175,10 +175,10 @@ const Compression = ({
 	}, [ showSample ]);
 
 	useEffect( () => {
-		if ( 'speed_optimized' === compressionMode ) {
+		if ( 'speed_optimized' === compressionMode || 'quality_optimized' === compressionMode ) {
 			transformCompressionMode( compressionMode );
 		}
-	}, [ compressionMode, transformCompressionMode ]);
+	}, []);
 
 	return (
 		<>

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -60,7 +60,7 @@ class Optml_Settings {
 		'admin_bar_item'             => 'enabled',
 		'lazyload'                   => 'disabled',
 		'scale'                      => 'disabled',
-		'network_optimization'       => 'disabled',
+		'network_optimization'       => 'enabled',
 		'lazyload_placeholder'       => 'enabled',
 		'bg_replacer'                => 'enabled',
 		'video_lazyload'             => 'enabled',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

- Enabled `network_optimization` as the default for new users to match the Speed Optimization profile.

Closes https://github.com/Codeinwp/optimole-service/issues/1560


https://github.com/user-attachments/assets/d5f71110-c6ec-4f4d-a2ad-b62ae04e567b

#### How to test

1. Use a new account on a new instance
2. Check if the Network Optimization is enabled when going to Custom

> [!WARNING]
> AVIF will be hidden in https://github.com/Codeinwp/optimole-wp/pull/975 so we can ignored in this PR

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
