### PR TITLE
Improve quality setting handling in Compression settings

### DIFF
--- a/assets/src/dashboard/parts/connected/settings/Compression.js
+++ b/assets/src/dashboard/parts/connected/settings/Compression.js
@@ -23,7 +23,7 @@ import {
 
 import { useSelect } from '@wordpress/data';
 
-import { useEffect, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -95,7 +95,7 @@ const Compression = ({
 		}
 
 		manualQualityRef.current = getQuality( settings.quality );
-	}, [ isAutoQualityEnabled, settings.quality ] );
+	}, [ isAutoQualityEnabled, settings.quality ]);
 	const updateOption = ( option, value ) => {
 		setCanSave( true );
 		const data = { ...settings };
@@ -333,18 +333,18 @@ const Compression = ({
 					<BaseControl
 						help={ ! isAutoQualityEnabled && optimoleDashboardApp.strings.options_strings.quality_desc }
 					>
-					<ToggleControl
-						label={ optimoleDashboardApp.strings.options_strings.quality_title }
-						help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.ml_quality_desc } } /> }
-						checked={ isAutoQualityEnabled }
-						disabled={ isLoading }
-						className={ classnames(
-							{
-								'is-disabled': isLoading
-							}
-						) }
-						onChange={ handleAutoQualityToggle }
-					/>
+						<ToggleControl
+							label={ optimoleDashboardApp.strings.options_strings.quality_title }
+							help={ () => <p dangerouslySetInnerHTML={ { __html: optimoleDashboardApp.strings.options_strings.ml_quality_desc } } /> }
+							checked={ isAutoQualityEnabled }
+							disabled={ isLoading }
+							className={ classnames(
+								{
+									'is-disabled': isLoading
+								}
+							) }
+							onChange={ handleAutoQualityToggle }
+						/>
 					</BaseControl>
 
 					{ ! isAutoQualityEnabled && (

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -280,7 +280,7 @@ class Optml_Settings {
 					$sanitized_value = $this->to_bound_integer( $value, 100, 5000 );
 					break;
 				case 'quality':
-					$sanitized_value = $this->to_bound_integer( $value, 1, 100 );
+					$sanitized_value = $this->to_bound_integer( $value, 50, 100 );
 					break;
 				case 'wm_id':
 					$sanitized_value = intval( $value );


### PR DESCRIPTION
Refactored the Compression.js component to better handle toggling between auto and manual quality settings while fixing https://github.com/Codeinwp/optimole-service/issues/1516#issuecomment-3355204589. Updated the minimum allowed quality value in settings.php from 1 to 50 to stay consistent with the front-end. 

Changed default compression setting to 80, which is more likely to be used vs 90, which is not recommended.

### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
 Refactored the Compression.js component to better handle toggling between auto and manual quality settings while fixing https://github.com/Codeinwp/optimole-service/issues/1516#issuecomment-3355204589. Updated the minimum allowed quality value in settings.php from 1 to 50 to stay consistent with the front-end. 

Changed default compression setting to 80, which is more likely to be used vs 90, which is not recommended.

Closes [#](https://github.com/Codeinwp/optimole-service/issues/1516) .

### How to test the changes in this Pull Request:

1. Disable machine learning compression & save
2. Ensure the default value is used on the frontend.
3. Make sure going back to mauto or migrating from an older version works as expected.

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ x] Have you successfully ran tests with your changes locally?
 
