### PR TITLE
fix: small tweaks for Lazy Load tab

### DIFF
--- a/assets/src/dashboard/parts/components/GroupSettingsContainer.js
+++ b/assets/src/dashboard/parts/components/GroupSettingsContainer.js
@@ -18,7 +18,7 @@ export const GroupSettingsTitle = ({ children, className = '' }) => {
 
 export const GroupSettingsOption = ({ children, className = '' }) => {
 	return (
-		<div className={classNames( 'text-sm text-gray-600 px-4 py-2 bg-white flex items-center rounded', className )}>
+		<div className={classNames( 'text-sm text-gray-600 px-4 py-2 bg-white flex flex-wrap items-center rounded', className )}>
 			{ children }
 		</div>
 	);

--- a/assets/src/dashboard/parts/connected/settings/Lazyload.js
+++ b/assets/src/dashboard/parts/connected/settings/Lazyload.js
@@ -15,7 +15,8 @@ import {
 	ColorIndicator,
 	Button,
 	Popover,
-	CheckboxControl
+	CheckboxControl,
+	Tooltip
 } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 
@@ -39,6 +40,7 @@ import {
 	DescriptionWithTags,
 	TextWithWarningBadge
 } from '../../components/Miscellaneous';
+import { Icon, help } from '@wordpress/icons';
 
 const { options_strings } = optimoleDashboardApp.strings;
 
@@ -325,6 +327,7 @@ const Lazyload = ({ settings, setSettings, setCanSave }) => {
 									onChange={( value ) =>
 										updateValue( 'skip_lazyload_images', value )
 									}
+									disabled={! isFixedSkipLazyEnabled}
 									__nextHasNoMarginBottom={true}
 								/>
 							</div>
@@ -354,7 +357,8 @@ const Lazyload = ({ settings, setSettings, setCanSave }) => {
 							{options_strings.visual_settings}
 						</GroupSettingsTitle>
 						<GroupSettingsOption>
-							<div className="grow" htmlFor="optml-lazyload-placeholder">
+
+							<div className="grow flex flex-row gap-1" htmlFor="optml-lazyload-placeholder">
 								<CheckboxControl
 									label={options_strings.enable_lazyload_placeholder_title}
 									checked={isLazyLoadPlaceholderEnabled}
@@ -364,8 +368,21 @@ const Lazyload = ({ settings, setSettings, setCanSave }) => {
 									disabled={isLoading}
 									__nextHasNoMarginBottom={true}
 								/>
+								<Tooltip
+									text={<p
+										className=""
+										dangerouslySetInnerHTML={{
+											__html: options_strings.enable_lazyload_placeholder_desc
+										}}
+									/>}
+								>
+									<Icon
+										icon={ help }
+										size={ 18 }
+										className="text-gray-400 hover:text-gray-600"
+									/>
+								</Tooltip>
 							</div>
-
 							{isLazyLoadPlaceholderEnabled && (
 								<div className="relative inline-block">
 									<Button

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1816,7 +1816,12 @@ The root cause might be either a security plugin which blocks this feature or so
 					'<a class="inline-block text-purple-gray underline" target=”_blank” href="https://docs.optimole.com/article/1943-avif-conversion">',
 					'</a>'
 				),
-				'enable_bg_lazyload_desc'             => __( 'Apply lazy loading to CSS background images. The toggle below enables it globally. The selector list is optional and only needed to extend coverage if certain elements are missed.', 'optimole-wp' ),
+				'enable_bg_lazyload_desc'             => sprintf(
+				/* translators: 1 is the starting anchor tag, 2 is the ending anchor tag */
+					__( 'Apply lazy loading to CSS background images. The toggle below enables it globally. The selector list is optional and only needed to extend coverage if certain elements are missed. %1$sLearn more%2$s', 'optimole-wp' ),
+					'<a class="inline-block text-purple-gray underline" target="_blank" href="https://docs.optimole.com/article/1169-how-to-enable-the-background-lazyload-feature-for-certain-background-images">',
+					'</a>'
+				),
 				'enable_bg_lazyload_title'            => __( 'CSS Background Lazy Load', 'optimole-wp' ),
 				'enable_video_lazyload_desc'          => __( 'Lazy load embedded videos and iframe content', 'optimole-wp' ),
 				'enable_video_lazyload_title'         => __( 'Video & iframes', 'optimole-wp' ),
@@ -1841,8 +1846,8 @@ The root cause might be either a security plugin which blocks this feature or so
 				'enable_image_replace'                => __( 'Enable Optimole Image Handling', 'optimole-wp' ),
 				'enable_lazyload_placeholder_desc'    => sprintf(
 				/* translators: 1 is the starting anchor tag, 2 is the ending anchor tag */
-					__( 'Enable this to use a generic transparent placeholder instead of the blurry images during lazy loading. Enhance the visual experience by selecting a custom color for the placeholder. %1$sLearn more%2$s', 'optimole-wp' ),
-					'<a class="inline-block text-purple-gray underline" target=”_blank” href="https://docs.optimole.com/article/1192-lazy-load-generic-placeholder">',
+					__( 'Enable this to use a generic transparent placeholder instead of the blurry images during lazy loading. %1$sLearn more%2$s', 'optimole-wp' ),
+					'<a class="inline-block underline text-white" target=”_blank” href="https://docs.optimole.com/article/1192-lazy-load-generic-placeholder">',
 					'</a>'
 				),
 
@@ -1855,7 +1860,7 @@ The root cause might be either a security plugin which blocks this feature or so
 				),
 				'lazyload_behaviour_all'             => __( 'Lazy Load All Images', 'optimole-wp' ),
 				'lazyload_behaviour_all_desc'        => __( 'All images will use lazy loading regardless of position.', 'optimole-wp' ),
-				'lazyload_behaviour_viewport'          => __( 'Enable viewport-based loading', 'optimole-wp' ),
+				'lazyload_behaviour_viewport'          => __( 'Skip images above the fold', 'optimole-wp' ),
 				'lazyload_behaviour_viewport_desc'   => __( 'Automatically detects and immediately loads images visible in the initial viewport. Detection is done with a lightweight client-side script that identifies what\'s visible on each user\'s screen. All other images will lazy load.', 'optimole-wp' ),
 				'lazyload_behaviour_fixed'           => __( 'Skip lazy loading for first images', 'optimole-wp' ),
 				'lazyload_behaviour_fixed_desc'      => __( 'Indicate how many images at the top of each page should bypass lazy loading, ensuring they\'re instantly visible.', 'optimole-wp' ),
@@ -1977,7 +1982,7 @@ The root cause might be either a security plugin which blocks this feature or so
 				'low_q_title'                         => __( 'Low', 'optimole-wp' ),
 				'medium_q_title'                      => __( 'Medium', 'optimole-wp' ),
 				'no_images_found'                     => __( 'You dont have any images in your Media Library. Add one and check how the Optimole will perform.', 'optimole-wp' ),
-				'native_desc'                         => __( 'Uses the browser\'s build-in "lazy" behavior', 'optimole-wp' ),
+				'native_desc'                         => __( 'Uses the browser\'s built-in lazy loading feature. Enabling this will disable the auto scale.', 'optimole-wp' ),
 				'option_saved'                        => __( 'Option saved.', 'optimole-wp' ),
 				'ml_quality_desc'                     => sprintf( /* translators: 1 is the starting anchor tag, 2 is the ending anchor tag */ __( 'Optimole ML algorithms will predict the optimal image quality to get the smallest possible size with minimum perceived quality losses. When disabled, you can control the quality manually. %1$sLearn more%2$s', 'optimole-wp' ), '<a class="inline-block text-purple-gray underline" target=”_blank” href="https://docs.optimole.com/article/1016-what-is-the-difference-between-the-auto-high-medium-low-compression-levels">', '</a>' ),
 				'quality_desc'                        => __( 'Lower image quality might boost your loading speed by lowering the size. However, the low image quality may negatively impact the visual appearance of the images. Try experimenting with the setting, then click the View sample image link to see what option works best for you.', 'optimole-wp' ),

--- a/inc/lazyload_replacer.php
+++ b/inc/lazyload_replacer.php
@@ -169,6 +169,7 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 		if ( self::$skip_lazyload_images !== null ) {
 			return self::$skip_lazyload_images;
 		}
+
 		self::$skip_lazyload_images = apply_filters( 'optml_lazyload_images_skip', self::instance()->settings->get( 'skip_lazyload_images' ) );
 		return self::$skip_lazyload_images;
 	}

--- a/inc/v2/Offload/Loader.php
+++ b/inc/v2/Offload/Loader.php
@@ -25,7 +25,7 @@ class Loader {
 	 * Adds filters to integrate the custom image editor into WordPress.
 	 */
 	public function register_hooks() {
-		if( has_filter( 'wp_image_editors', 'photon_subsizes_override_image_editors' )){
+		if ( has_filter( 'wp_image_editors', 'photon_subsizes_override_image_editors' ) ) {
 			return;
 		}
 		add_filter( 'wp_image_editors', [ $this, 'register_image_editor' ] );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:

Based on https://github.com/Codeinwp/optimole-service/issues/1559#issuecomment-3362609201
 
 - Add the requested tweaks to the UI for the Lazy Load page

<img width="2684" height="1554" alt="CleanShot 2025-10-08 at 13 09 26@2x" src="https://github.com/user-attachments/assets/fafb11d2-c51b-453d-8337-70b1052e2e81" />

<img width="2868" height="3238" alt="CleanShot 2025-10-08 at 14 22 23@2x" src="https://github.com/user-attachments/assets/aa41c867-f092-40d0-87a6-0fb6728e3e40" />


Closes https://github.com/Codeinwp/optimole-service/issues/1559#issuecomment-3362609201

### How to test the changes in this Pull Request:

1. Check the UI


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
 
