### PR TITLE
fix: type verification for filter values

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -575,11 +575,14 @@ class Optml_Admin {
 	/**
 	 * Add settings links in the plugin listing page.
 	 *
-	 * @param string[] $links Old plugin links.
+	 * @param string[]|mixed $links Old plugin links.
 	 *
-	 * @return string[] Altered links.
+	 * @return string[]|mixed Altered links.
 	 */
 	public function add_action_links( $links ) {
+		if ( ! is_array( $links ) ) {
+			return $links;
+		}
 		return array_merge(
 			$links,
 			[

--- a/inc/app_replacer.php
+++ b/inc/app_replacer.php
@@ -654,10 +654,10 @@ abstract class Optml_App_Replacer {
 	/**
 	 * Get the optimized image url for the image url.
 	 *
-	 * @param string $url    The image URL.
-	 * @param mixed  $width  The image width.
-	 * @param mixed  $height The image height.
-	 * @param array  $resize The resize properties.
+	 * @param string                     $url    The image URL.
+	 * @param mixed                      $width  The image width.
+	 * @param mixed                      $height The image height.
+	 * @param array<string, mixed>|mixed $resize The resize properties.
 	 *
 	 * @return string
 	 */
@@ -668,7 +668,7 @@ abstract class Optml_App_Replacer {
 			->width( $width )
 			->height( $height );
 
-		if ( ! empty( $resize['type'] ) ) {
+		if ( is_array( $resize ) && ! empty( $resize['type'] ) ) {
 			$optimized_image->resize( $resize['type'], $resize['gravity'] ?? Position::CENTER, $resize['enlarge'] ?? false );
 
 		}

--- a/inc/tag_replacer.php
+++ b/inc/tag_replacer.php
@@ -809,15 +809,18 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 	/**
 	 * Replace image URLs in the srcset attributes and in case there is a resize in action, also replace the sizes.
 	 *
-	 * @param array<int, array{url: string, descriptor: string, value: int}> $sources Array of image sources.
-	 * @param array{0: int, 1: int}|int[]                                    $size_array Array of width and height values in pixels (in that order).
-	 * @param string                                                         $image_src The 'src' of the image.
-	 * @param array<string, mixed>                                           $image_meta The image meta data as returned by 'wp_get_attachment_metadata()'.
-	 * @param int                                                            $attachment_id Image attachment ID or 0.
+	 * @param array<int, array{url: string, descriptor: string, value: int}>|mixed $sources Array of image sources.
+	 * @param array{0: int, 1: int}|int[]                                          $size_array Array of width and height values in pixels (in that order).
+	 * @param string                                                               $image_src The 'src' of the image.
+	 * @param array<string, mixed>                                                 $image_meta The image meta data as returned by 'wp_get_attachment_metadata()'.
+	 * @param int                                                                  $attachment_id Image attachment ID or 0.
 	 *
-	 * @return array
+	 * @return array|mixed
 	 */
 	public function filter_srcset_attr( $sources = [], $size_array = [], $image_src = '', $image_meta = [], $attachment_id = 0 ) {
+		if ( ! is_array( $sources ) ) {
+			return $sources;
+		}
 		if ( Optml_Media_Offload::is_uploaded_image( $image_src ) ) {
 			return $sources;
 		}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -517,12 +517,6 @@ parameters:
 			path: inc/app_replacer.php
 
 		-
-			message: '#^Method Optml_App_Replacer\:\:get_optimized_image_url\(\) has parameter \$resize with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: inc/app_replacer.php
-
-		-
 			message: '#^Method Optml_App_Replacer\:\:get_upload_resource\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -2787,12 +2781,6 @@ parameters:
 		-
 			message: '#^Method Optml_Tag_Replacer\:\:filter_image_src_get_dimensions\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: inc/tag_replacer.php
-
-		-
-			message: '#^Method Optml_Tag_Replacer\:\:filter_srcset_attr\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: inc/tag_replacer.php
 


### PR DESCRIPTION
Re-add the extra type verification for values that are computed with filters.

### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
Re-add some type verifications from https://github.com/Codeinwp/optimole-wp/commit/407e4febe66d6d4f017c004738cb6fa926e0c12d

Closes https://github.com/Codeinwp/optimole-wp/issues/1002

### How to test the changes in this Pull Request:

1. Add a custom filter for the WP hook 'wp_calculate_image_srcset' that returns a non-array value.
2. Check the logs for warnings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
