### PR TITLE
fix: compatibility with otter blocks background images defined in CSS files

### DIFF
--- a/inc/compatibilities/otter_blocks.php
+++ b/inc/compatibilities/otter_blocks.php
@@ -7,7 +7,6 @@
  */
 class Optml_otter_blocks extends Optml_compatibility {
 
-
 	/**
 	 * Should we load the integration logic.
 	 *
@@ -39,5 +38,43 @@ class Optml_otter_blocks extends Optml_compatibility {
 
 		// Replace the image URL with the optimized one in Otter-generated CSS.
 		add_filter( 'otter_apply_dynamic_image', [ Optml_Main::instance()->manager->url_replacer, 'build_url' ], 99 );
+
+		// Ensure replacer is initialized for Otter REST API routes (where register_hooks isn't called).
+		add_filter( 'rest_pre_dispatch', [ $this, 'maybe_init_replacer_for_rest' ], 10, 3 );
+	}
+
+	/**
+	 * Initialize replacer for Otter REST API routes.
+	 *
+	 * @param mixed            $result  Response to replace the requested version with.
+	 * @param \WP_REST_Server  $server  Server instance.
+	 * @param \WP_REST_Request $request Request used to generate the response.
+	 * @return mixed Unmodified result.
+	 */
+	public function maybe_init_replacer_for_rest( $result, \WP_REST_Server $server, \WP_REST_Request $request ) {
+		$route = $request->get_route();
+
+		// Only initialize for Otter styles REST routes.
+		if ( strpos( $route, '/otter/v1/post_styles' ) === false
+			&& strpos( $route, '/otter/v1/widget_styles' ) === false
+			&& strpos( $route, '/otter/v1/block_styles' ) === false
+		) {
+			return $result;
+		}
+
+		if ( ! did_action( 'optml_replacer_setup' ) ) {
+			do_action( 'optml_replacer_setup' );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Should we early load the compatibility?
+	 *
+	 * @return bool Whether to load the compatibility early.
+	 */
+	public function should_load_early() {
+		return true;
 	}
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1021,6 +1021,12 @@ parameters:
 			path: inc/compatibilities/metaslider.php
 
 		-
+			message: '#^Method Optml_otter_blocks\:\:maybe_init_replacer_for_rest\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
+			identifier: missingType.generics
+			count: 1
+			path: inc/compatibilities/otter_blocks.php
+
+		-
 			message: '#^Method Optml_otter_blocks\:\:register\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
 
- Fixes issue where CSS files generated on post save didn't have the image URLs replaced;
- Properly sets up the replacer on the specific rest routes used to generate the CSS files;
- This was previously already working when regenerating the CSS, but not when saving the post;

Closes Codeinwp/optimole-service#1594.

### How to test the changes in this Pull Request:

1. Install Otter Blocks;
2. Add the following line in a `.php` file under `/wp-content/mu-plugins` to make sure CSS is generated regardless of how large the Otter styles on a page are:
  - `add_filter('styles_inline_size_limit', '__return_zero');`  
3. Create a page containing one or more Otter section blocks and add background images to them;
4. Save and publish the page;
5. On the frontend, check the browser inspector, the background image should be loaded from Optimole CDN;

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
