### PR TITLE
Prevent buffer flush conflicts

### DIFF
--- a/inc/manager.php
+++ b/inc/manager.php
@@ -407,7 +407,7 @@ final class Optml_Manager {
 		);
 		add_action( 'template_redirect', [ $this, 'register_after_setup' ] );
 		add_action( 'rest_api_init', [ $this, 'process_template_redirect_content' ], PHP_INT_MIN );
-		add_action( 'shutdown', [ $this, 'close_buffer' ] );
+		add_action( 'shutdown', [ $this, 'close_buffer' ], PHP_INT_MIN );
 		foreach ( self::$loaded_compatibilities as $registered_compatibility ) {
 			$registered_compatibility->register();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 

### Changes proposed in this Pull Request:
Set the priority of shutdown action to higher to avoid the buffer flush conflicts.

Closes https://github.com/Codeinwp/optimole-wp/issues/1014

### How to test the changes in this Pull Request:

1. Connect the account.
2. Add a filter to exclude the page from lazy loading with the filter value of page URL matches any string value.
3. Visit the page as a non-logged-in user and check that the error does not exist. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
