### PR TITLE
fix: prevent fatal error with list() assignment on missing images in PHP 8.2+

### DIFF
--- a/inc/lazyload_replacer.php
+++ b/inc/lazyload_replacer.php
@@ -529,7 +529,11 @@ final class Optml_Lazyload_Replacer extends Optml_App_Replacer {
 					wp_cache_add( $key, [ $sizes[0], $sizes[1] ], 'optml_sources', DAY_IN_SECONDS );
 				}
 			}
-			list( $width, $height ) = $sizes;
+			// Check if $sizes is an array before list() assignment to prevent fatal error on PHP 8.2+
+			// when the image file is missing (e.g., offloaded to CDN or deleted).
+			if ( is_array( $sizes ) ) {
+				list( $width, $height ) = $sizes;
+			}
 		}
 		// If the width is not found the url might be an offloaded attachment so we can get the width and height from the metadata.
 		if ( ! is_numeric( $width ) && ! empty( $url ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 

### Changes proposed in this Pull Request:

Fix a fatal error that occurs in PHP 8.2+ when the lazyload placeholder feature is enabled and an image file is missing from the local uploads directory (e.g., offloaded to CDN or deleted).

The issue occurs in `inc/lazyload_replacer.php` at line 532 where `list($width, $height) = $sizes` is called, but `` can be `false` when the image file doesn't exist. PHP 8.2+ requires the argument to `list()` to be an array.

Closes #1034.

### How to test the changes in this Pull Request:

1. Use PHP 8.2 or higher
2. Enable Lazyload with "Use placeholder" option
3. Have an image that is offloaded to Optimole CDN
4. Delete the local copy of the image
5. View a post containing that image
6. **Before fix**: Fatal error `TypeError: list(): Argument #1 ($array) must be of type array, bool given`
7. **After fix**: No error; placeholder SVG uses fallback dimensions (100% width/height or dimensions from attachment metadata)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?