### PR TITLE
fix: cap srcset against naturalWidth instead of currentWidth

### DIFF
--- a/assets/js/modules/srcset-detector.js
+++ b/assets/js/modules/srcset-detector.js
@@ -437,9 +437,10 @@ export const optmlSrcsetDetector = {
         const targetWidth = Math.round(baseWidth * dprValue);
         const targetHeight = Math.round(targetWidth / aspectRatio);
         
-        // Don't generate 1x DPR variations larger than current size
+        // Don't generate 1x DPR variations larger than natural image size
         // But allow 2x DPR variations for retina displays
-        if (dprValue === 1 && targetWidth > currentWidth) {
+        // Fixes: srcset capped at profiling container width (issue #1030)
+        if (dprValue === 1 && targetWidth > naturalWidth) {
           return;
         }
         


### PR DESCRIPTION
## Summary

Fixes #1030 - srcset capped at profiling container width, causing blurry images on wider viewports.

## Problem

When Optimole's JS page profiler measures an image on a desktop screen (e.g. 1440px wide), it stores srcset entries capped at that container width. Visitors on wider screens (e.g. 1750px) then receive a srcset whose largest 1x entry is 1440px, causing visible blur.

## Root Cause

In _generateResponsiveSizes(), the condition was capping against currentWidth (CSS-rendered size) instead of naturalWidth (actual image pixel width).

## Fix

Changed the condition to cap against naturalWidth instead, ensuring 1x srcset variants are generated for all breakpoints up to the image's actual pixel width.

## Files Changed

- assets/js/modules/srcset-detector.js - 1 line change