### PR TITLE
Displayed correct notice when disabling scaling option

### DIFF
--- a/assets/src/dashboard/parts/connected/settings/Lazyload.js
+++ b/assets/src/dashboard/parts/connected/settings/Lazyload.js
@@ -204,7 +204,7 @@ const Lazyload = ({ settings, setSettings, setCanSave }) => {
 					labels={{
 						title: options_strings.performance_impact_alert_title,
 						description:
-							'scale' === showModal ?
+							DISABLE_OPTION_MODAL_TYPE.scale === showModal ?
 								options_strings.performance_impact_alert_scale_desc :
 								options_strings.performance_impact_alert_lazy_desc,
 						action: options_strings.performance_impact_alert_action_label,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
Compared the correct value with `showModal` to display the correct notice.

Closes https://github.com/Codeinwp/optimole-wp/issues/1040

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?