### PR TITLE
Escaped URLs to prevent XSS

### DIFF
--- a/inc/url_replacer.php
+++ b/inc/url_replacer.php
@@ -163,7 +163,10 @@ final class Optml_Url_Replacer extends Optml_App_Replacer {
 			$url = sprintf( '%s://%s', is_ssl() ? 'https' : 'http', $url );
 		}
 		$normalized_ext = strtolower( $ext );
-		$url            = esc_url( $url );
+		$url = esc_url( $url );
+		if ( empty( $url ) ) {
+			return $original_url;
+		}
 		if ( isset( Optml_Config::$image_extensions[ $normalized_ext ] ) ) {
 			$new_url = $this->normalize_image( $url, $original_url, $args, $is_uploaded, $normalized_ext );
 			if ( $is_uploaded ) {

--- a/inc/url_replacer.php
+++ b/inc/url_replacer.php
@@ -163,6 +163,7 @@ final class Optml_Url_Replacer extends Optml_App_Replacer {
 			$url = sprintf( '%s://%s', is_ssl() ? 'https' : 'http', $url );
 		}
 		$normalized_ext = strtolower( $ext );
+		$url            = esc_url( $url );
 		if ( isset( Optml_Config::$image_extensions[ $normalized_ext ] ) ) {
 			$new_url = $this->normalize_image( $url, $original_url, $args, $is_uploaded, $normalized_ext );
 			if ( $is_uploaded ) {


### PR DESCRIPTION
### Summary:
Escaping the URL before passing it to the Optimole SDK to prevent XSS vulnerabilities.

### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?  


Closes https://github.com/Codeinwp/optimole-service/issues/1711

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
