### PR TITLE
Handled non-array option values

### DIFF
--- a/inc/main.php
+++ b/inc/main.php
@@ -157,6 +157,8 @@ final class Optml_Main {
 	 * @return array
 	 */
 	public static function add_settings( $data ): array {
+		$data = is_array( $data ) ? $data : [];
+
 		$saved_data = ( new Optml_Settings() )->get_raw_settings();
 		unset( $saved_data['service_data'] );
 		unset( $saved_data['api_key'] );

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -783,7 +783,9 @@ class Optml_Settings {
 	 * @return  array
 	 */
 	public function get_raw_settings() {
-		return get_option( $this->namespace, false );
+		$raw_settings = get_option( $this->namespace, [] );
+
+		return is_array( $raw_settings ) ? $raw_settings : [];
 	}
 
 

--- a/tests/test-logger-data.php
+++ b/tests/test-logger-data.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * WordPress unit test plugin.
+ *
+ * Covers the `optimole_wp_logger_data` filter used by the SDK logger cron
+ * (`optimole_wp_log_activity`) when no settings have been stored yet.
+ *
+ * @package     Optimole-WP
+ * @subpackage  Tests
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+class Test_Logger_Data extends WP_UnitTestCase {
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		// The rollback restored the option, refresh the static settings cache from it.
+		new Optml_Settings();
+	}
+
+	/**
+	 * Raw settings must be an array even when the option was never stored.
+	 */
+	public function test_get_raw_settings_returns_array_when_option_missing() {
+		delete_option( OPTML_NAMESPACE . '_settings' );
+
+		$raw_settings = ( new Optml_Settings() )->get_raw_settings();
+
+		$this->assertIsArray( $raw_settings );
+		$this->assertSame( [], $raw_settings );
+	}
+
+	/**
+	 * Raw settings must be an array even when the option holds a non-array value.
+	 */
+	public function test_get_raw_settings_returns_array_when_option_is_not_an_array() {
+		update_option( OPTML_NAMESPACE . '_settings', 'corrupted' );
+
+		$this->assertSame( [], ( new Optml_Settings() )->get_raw_settings() );
+	}
+
+	/**
+	 * `add_settings` must not fatal when there is nothing stored in the database.
+	 */
+	public function test_add_settings_with_missing_option() {
+		delete_option( OPTML_NAMESPACE . '_settings' );
+
+		$data = Optml_Main::add_settings( [ 'foo' => 'bar' ] );
+
+		$this->assertIsArray( $data );
+		$this->assertSame( [ 'foo' => 'bar' ], $data );
+	}
+
+	/**
+	 * Secrets are never sent along with the logger data.
+	 */
+	public function test_add_settings_strips_secrets() {
+		update_option(
+			OPTML_NAMESPACE . '_settings',
+			[
+				'api_key'      => 'secret-key',
+				'service_data' => [ 'cdn_key' => 'key', 'cdn_secret' => 'secret' ],
+				'quality'      => 'auto',
+			]
+		);
+
+		$data = Optml_Main::add_settings( [] );
+
+		$this->assertArrayNotHasKey( 'api_key', $data );
+		$this->assertArrayNotHasKey( 'service_data', $data );
+		$this->assertSame( 'auto', $data['quality'] );
+	}
+
+	/**
+	 * The logger cron collects its payload through this filter, it must survive a site
+	 * where Optimole settings were never saved.
+	 */
+	public function test_logger_data_filter_without_stored_settings() {
+		delete_option( OPTML_NAMESPACE . '_settings' );
+
+		$this->assertNotFalse( has_filter( 'optimole_wp_logger_data', [ 'Optml_Main', 'add_settings' ] ) );
+		$this->assertIsArray( apply_filters( 'optimole_wp_logger_data', [] ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
Return the Optimole settings as an array instead of false when the settings are not set. This is to avoid errors when merging the settings with other arrays.

Closes https://github.com/Codeinwp/optimole-wp/issues/1099

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
