### PR TITLE
Sanitized above-fold image IDs to prevent XSS

### DIFF
--- a/inc/rest.php
+++ b/inc/rest.php
@@ -965,7 +965,7 @@ class Optml_Rest {
 		}
 		// save just the first 6 images, see https://github.com/Codeinwp/optimole-service/issues/1588#issuecomment-3357110865
 		$above_fold_images = array_slice( $above_fold_images, 0, 6 );
-		$above_fold_images = array_values( array_filter( array_map( 'intval', $above_fold_images ) ) );
+		$above_fold_images = array_values( array_map( 'intval', array_filter( $above_fold_images, 'is_numeric' ) ) );
 		if ( count( $bg_selectors ) > 100 ) {
 			return $this->response( 'Background selectors limit exceeded', 'error' );
 		}

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -965,6 +965,7 @@ class Optml_Rest {
 		}
 		// save just the first 6 images, see https://github.com/Codeinwp/optimole-service/issues/1588#issuecomment-3357110865
 		$above_fold_images = array_slice( $above_fold_images, 0, 6 );
+		$above_fold_images = array_values( array_filter( array_map( 'intval', $above_fold_images ) ) );
 		if ( count( $bg_selectors ) > 100 ) {
 			return $this->response( 'Background selectors limit exceeded', 'error' );
 		}

--- a/inc/v2/PageProfiler/Profile.php
+++ b/inc/v2/PageProfiler/Profile.php
@@ -156,7 +156,7 @@ class Profile {
 	 *
 	 * @param string                                                                              $id The profile ID.
 	 * @param int                                                                                 $device_type The device type constant.
-	 * @param array<string>                                                                       $above_fold_images Array of above-fold images.
+	 * @param array<int|string>                                                                   $above_fold_images Array of above-fold image ids.
 	 * @param array<string, array<string, array<int, string>>>                                    $af_bg_selectors Array of above-fold background selectors.
 	 *                                        Array structure:
 	 *                                        [
@@ -482,7 +482,7 @@ class Profile {
 		// Add device-specific metrics
 		foreach ( $profile_data as $device_type => $device_data ) {
 			$device_name = $this->get_device_name( $device_type );
-			$comment_parts[] = 'measurement#device-' . $device_name . '#' . json_encode( $device_data );
+			$comment_parts[] = 'measurement#device-' . $device_name . '#' . json_encode( $device_data, JSON_HEX_TAG | JSON_HEX_AMP );
 		}
 
 		return '<!-- ' . implode( ' ', $comment_parts ) . ' -->';

--- a/tests/test-lazyload-viewport.php
+++ b/tests/test-lazyload-viewport.php
@@ -467,6 +467,37 @@ class Test_Lazyload_Viewport extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The debug HTML comment must never be broken out of by stored profile data.
+	 *
+	 * Regression test for the unauthenticated stored XSS: a malicious above-fold
+	 * image key must not emit a raw `-->` or `<` inside the profiler debug comment.
+	 */
+	public function test_profile_html_comment_cannot_break_out() {
+		$payload = '--><img src=x onerror=alert(document.domain)><!--marker';
+
+		$this->storeMockProfileData(
+			self::mock_page_ids(),
+			Profile::DEVICE_TYPE_DESKTOP,
+			[ $payload ]
+		);
+		$this->storeMockProfileData(
+			self::mock_page_ids(),
+			Profile::DEVICE_TYPE_MOBILE,
+			[ $payload ]
+		);
+
+		$comment = Optml_Manager::instance()->page_profiler->get_current_profile_html_comment();
+
+		// Comment stays a single well-formed HTML comment.
+		$this->assertStringStartsWith('<!--', $comment);
+		$this->assertStringEndsWith('-->', $comment);
+		// Body between the delimiters must contain no raw < or > to break out with.
+		$body = substr($comment, 4, -3);
+		$this->assertStringNotContainsString('<', $body);
+		$this->assertStringNotContainsString('>', $body);
+	}
+
+	/**
 	 * Get sample HTML content for testing.
 	 *
 	 * @return string The sample HTML.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

### Changes proposed in this Pull Request:
Handling the above-the-fold image data in profiler debug comments to prevent XSS (cross-site scripting) via malformed or malicious image IDs.

Closes https://github.com/Codeinwp/optimole-service/issues/1776

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
