### PR TITLE
fix: coerce object-shaped page profiles before viewport lookup

### DIFF
--- a/inc/v2/BgOptimizer/Lazyload.php
+++ b/inc/v2/BgOptimizer/Lazyload.php
@@ -3,7 +3,6 @@
 namespace OptimoleWP\BgOptimizer;
 
 use OptimoleWP\PageProfiler\Profile;
-use OptimoleWP\PageProfiler\Storage\Base as ProfilerStorage;
 use OptimoleWP\Preload\Links;
 use Optml_Lazyload_Replacer;
 
@@ -35,21 +34,8 @@ class Lazyload {
 		$css_selectors = [];
 		$preload_urls = [];
 		foreach ( Profile::get_active_devices() as $device ) {
-			$device_data = $data[ $device ] ?? [];
-			if ( ! is_array( $device_data ) ) {
-				$device_data = ProfilerStorage::normalize_value( $device_data );
-				$device_data = is_array( $device_data ) ? $device_data : [];
-			}
-			$personalized_selectors = $device_data['bg'] ?? [];
-			if ( ! is_array( $personalized_selectors ) ) {
-				$personalized_selectors = ProfilerStorage::normalize_value( $personalized_selectors );
-				$personalized_selectors = is_array( $personalized_selectors ) ? $personalized_selectors : [];
-			}
-			$lcp_data = $device_data['lcp'] ?? [];
-			if ( ! is_array( $lcp_data ) ) {
-				$lcp_data = ProfilerStorage::normalize_value( $lcp_data );
-				$lcp_data = is_array( $lcp_data ) ? $lcp_data : [];
-			}
+			$personalized_selectors = $data[ $device ]['bg'] ?? [];
+			$lcp_data = $data[ $device ]['lcp'] ?? [];
 			if ( OPTML_DEBUG ) {
 				do_action( 'optml_log', 'personalized_selectors: ' . $device . ' ' . print_r( $personalized_selectors, true ) );
 				do_action( 'optml_log', 'LCP data: ' . $device . ' ' . print_r( $lcp_data, true ) );

--- a/inc/v2/BgOptimizer/Lazyload.php
+++ b/inc/v2/BgOptimizer/Lazyload.php
@@ -3,6 +3,7 @@
 namespace OptimoleWP\BgOptimizer;
 
 use OptimoleWP\PageProfiler\Profile;
+use OptimoleWP\PageProfiler\Storage\Base as ProfilerStorage;
 use OptimoleWP\Preload\Links;
 use Optml_Lazyload_Replacer;
 
@@ -34,8 +35,21 @@ class Lazyload {
 		$css_selectors = [];
 		$preload_urls = [];
 		foreach ( Profile::get_active_devices() as $device ) {
-			$personalized_selectors = $data[ $device ]['bg'] ?? [];
-			$lcp_data = $data[ $device ]['lcp'] ?? [];
+			$device_data = $data[ $device ] ?? [];
+			if ( ! is_array( $device_data ) ) {
+				$device_data = ProfilerStorage::normalize_value( $device_data );
+				$device_data = is_array( $device_data ) ? $device_data : [];
+			}
+			$personalized_selectors = $device_data['bg'] ?? [];
+			if ( ! is_array( $personalized_selectors ) ) {
+				$personalized_selectors = ProfilerStorage::normalize_value( $personalized_selectors );
+				$personalized_selectors = is_array( $personalized_selectors ) ? $personalized_selectors : [];
+			}
+			$lcp_data = $device_data['lcp'] ?? [];
+			if ( ! is_array( $lcp_data ) ) {
+				$lcp_data = ProfilerStorage::normalize_value( $lcp_data );
+				$lcp_data = is_array( $lcp_data ) ? $lcp_data : [];
+			}
 			if ( OPTML_DEBUG ) {
 				do_action( 'optml_log', 'personalized_selectors: ' . $device . ' ' . print_r( $personalized_selectors, true ) );
 				do_action( 'optml_log', 'LCP data: ' . $device . ' ' . print_r( $lcp_data, true ) );

--- a/inc/v2/PageProfiler/Profile.php
+++ b/inc/v2/PageProfiler/Profile.php
@@ -226,9 +226,7 @@ class Profile {
 	 * @return array{w: int, h: int}|array{} The missing dimensions.
 	 */
 	public function get_missing_dimensions( int $image_id ): array {
-		$dimensions = self::get_device_member( self::DEVICE_TYPE_GLOBAL, 'm' )[ $image_id ] ?? [];
-
-		return is_array( $dimensions ) ? $dimensions : [];
+		return self::$current_profile_data[ self::DEVICE_TYPE_GLOBAL ]['m'][ $image_id ] ?? [];
 	}
 
 	/**
@@ -239,9 +237,7 @@ class Profile {
 	 * @return array<int, array{w: int, h: int, d: int, s: string, b: int}>|array{} The missing srcsets.
 	 */
 	public function get_missing_srcsets( int $image_id ): array {
-		$srcsets = self::get_device_member( self::DEVICE_TYPE_GLOBAL, 's' )[ $image_id ] ?? [];
-
-		return is_array( $srcsets ) ? $srcsets : [];
+		return self::$current_profile_data[ self::DEVICE_TYPE_GLOBAL ]['s'][ $image_id ] ?? [];
 	}
 
 	/**
@@ -252,7 +248,7 @@ class Profile {
 	 * @return bool The crop status.
 	 */
 	public function get_crop_status( int $image_id ): bool {
-		return (bool) ( self::get_device_member( self::DEVICE_TYPE_GLOBAL, 'c' )[ $image_id ] ?? false );
+		return self::$current_profile_data[ self::DEVICE_TYPE_GLOBAL ]['c'][ $image_id ] ?? false;
 	}
 	/**
 	 * Checks if profile data exists for all active device types.
@@ -345,9 +341,9 @@ class Profile {
 			return self::$current_profile_data;
 		}
 		self::$current_profile_data = [
-			self::DEVICE_TYPE_MOBILE  => Storage\Base::normalize_value( $this->storage->get( self::get_current_profile_id() . '_' . self::DEVICE_TYPE_MOBILE ) ),
-			self::DEVICE_TYPE_DESKTOP => Storage\Base::normalize_value( $this->storage->get( self::get_current_profile_id() . '_' . self::DEVICE_TYPE_DESKTOP ) ),
-			self::DEVICE_TYPE_GLOBAL  => Storage\Base::normalize_value( $this->storage->get( self::get_current_profile_id() ) ),
+			self::DEVICE_TYPE_MOBILE  => $this->storage->get( self::get_current_profile_id() . '_' . self::DEVICE_TYPE_MOBILE ),
+			self::DEVICE_TYPE_DESKTOP => $this->storage->get( self::get_current_profile_id() . '_' . self::DEVICE_TYPE_DESKTOP ),
+			self::DEVICE_TYPE_GLOBAL  => $this->storage->get( self::get_current_profile_id() ),
 		];
 		if ( OPTML_DEBUG ) {
 			do_action( 'optml_log', 'Profile data: ' . print_r( self::$current_profile_data, true ) . ' for id: ' . self::get_current_profile_id() );
@@ -365,14 +361,12 @@ class Profile {
 	 */
 	public function is_in_all_viewports( int $image_id ): bool {
 		foreach ( self::get_active_devices() as $device ) {
-			$device_data = self::get_device_data( $device );
 			// If the data is not available for the device, return false.
-			if ( empty( $device_data ) ) {
+			if ( empty( self::$current_profile_data[ $device ] ?? null ) ) {
 				return false;
 			}
 			// If the image is not in the viewport of the device, return false.
-			$above_fold = self::get_device_member( $device, 'af' );
-			if ( empty( $above_fold[ $image_id ] ) ) {
+			if ( ! ( self::$current_profile_data[ $device ]['af'][ $image_id ] ?? false ) ) {
 				return false;
 			}
 		}
@@ -390,8 +384,7 @@ class Profile {
 	 */
 	public function is_lcp_image_in_all_viewports( int $image_id ): bool {
 		foreach ( self::get_active_devices() as $device ) {
-			$lcp = self::get_device_member( $device, 'lcp' );
-			if ( ( $lcp['type'] ?? '' ) === 'img' && ( $lcp['imageId'] ?? null ) === $image_id ) {
+			if ( ( ( self::$current_profile_data[ $device ]['lcp']['type'] ?? '' ) === 'img' ) && ( ( self::$current_profile_data[ $device ]['lcp']['imageId'] ?? null ) === $image_id ) ) {
 				return true;
 			}
 		}
@@ -408,8 +401,7 @@ class Profile {
 	 */
 	public function is_in_any_viewport( $image_id ) {
 		foreach ( self::get_active_devices() as $device ) {
-			$above_fold = self::get_device_member( $device, 'af' );
-			if ( ! empty( $above_fold[ $image_id ] ) ) {
+			if ( self::$current_profile_data[ $device ]['af'][ $image_id ] ?? false ) {
 				return $device;
 			}
 		}
@@ -427,7 +419,7 @@ class Profile {
 	public function get_profile_data( $id ) {
 		$profile_data = [];
 		foreach ( self::get_active_devices() as $device ) {
-			$profile_data[ $device ] = Storage\Base::normalize_value( $this->storage->get( $id . '_' . $device ) );
+			$profile_data[ $device ] = $this->storage->get( $id . '_' . $device );
 		}
 
 		return $profile_data;
@@ -462,45 +454,12 @@ class Profile {
 	 */
 	public function is_data_available(): bool {
 		foreach ( self::get_active_devices() as $device ) {
-			if ( empty( self::get_device_data( $device ) ) ) {
+			if ( empty( self::$current_profile_data[ $device ] ) ) {
 				return false;
 			}
 		}
 
 		return true;
-	}
-
-	/**
-	 * Get array-shaped profile data for a device.
-	 *
-	 * Object-shaped cache values are coerced to arrays so viewport lookups never fatal.
-	 *
-	 * @param int $device Device type constant.
-	 * @return array<string, mixed>
-	 */
-	private static function get_device_data( int $device ): array {
-		$data = self::$current_profile_data[ $device ] ?? [];
-		if ( ! is_array( $data ) ) {
-			$data = Storage\Base::normalize_value( $data );
-		}
-
-		return is_array( $data ) ? $data : [];
-	}
-
-	/**
-	 * Get an array member from a device profile.
-	 *
-	 * @param int    $device Device type constant.
-	 * @param string $key    Member key (af, bg, lcp, m, s, c).
-	 * @return array<string|int, mixed>
-	 */
-	private static function get_device_member( int $device, string $key ): array {
-		$member = self::get_device_data( $device )[ $key ] ?? [];
-		if ( ! is_array( $member ) ) {
-			$member = Storage\Base::normalize_value( $member );
-		}
-
-		return is_array( $member ) ? $member : [];
 	}
 
 	/**

--- a/inc/v2/PageProfiler/Profile.php
+++ b/inc/v2/PageProfiler/Profile.php
@@ -226,7 +226,9 @@ class Profile {
 	 * @return array{w: int, h: int}|array{} The missing dimensions.
 	 */
 	public function get_missing_dimensions( int $image_id ): array {
-		return self::$current_profile_data[ self::DEVICE_TYPE_GLOBAL ]['m'][ $image_id ] ?? [];
+		$dimensions = self::get_device_member( self::DEVICE_TYPE_GLOBAL, 'm' )[ $image_id ] ?? [];
+
+		return is_array( $dimensions ) ? $dimensions : [];
 	}
 
 	/**
@@ -237,7 +239,9 @@ class Profile {
 	 * @return array<int, array{w: int, h: int, d: int, s: string, b: int}>|array{} The missing srcsets.
 	 */
 	public function get_missing_srcsets( int $image_id ): array {
-		return self::$current_profile_data[ self::DEVICE_TYPE_GLOBAL ]['s'][ $image_id ] ?? [];
+		$srcsets = self::get_device_member( self::DEVICE_TYPE_GLOBAL, 's' )[ $image_id ] ?? [];
+
+		return is_array( $srcsets ) ? $srcsets : [];
 	}
 
 	/**
@@ -248,7 +252,7 @@ class Profile {
 	 * @return bool The crop status.
 	 */
 	public function get_crop_status( int $image_id ): bool {
-		return self::$current_profile_data[ self::DEVICE_TYPE_GLOBAL ]['c'][ $image_id ] ?? false;
+		return (bool) ( self::get_device_member( self::DEVICE_TYPE_GLOBAL, 'c' )[ $image_id ] ?? false );
 	}
 	/**
 	 * Checks if profile data exists for all active device types.
@@ -341,9 +345,9 @@ class Profile {
 			return self::$current_profile_data;
 		}
 		self::$current_profile_data = [
-			self::DEVICE_TYPE_MOBILE  => $this->storage->get( self::get_current_profile_id() . '_' . self::DEVICE_TYPE_MOBILE ),
-			self::DEVICE_TYPE_DESKTOP => $this->storage->get( self::get_current_profile_id() . '_' . self::DEVICE_TYPE_DESKTOP ),
-			self::DEVICE_TYPE_GLOBAL  => $this->storage->get( self::get_current_profile_id() ),
+			self::DEVICE_TYPE_MOBILE  => Storage\Base::normalize_value( $this->storage->get( self::get_current_profile_id() . '_' . self::DEVICE_TYPE_MOBILE ) ),
+			self::DEVICE_TYPE_DESKTOP => Storage\Base::normalize_value( $this->storage->get( self::get_current_profile_id() . '_' . self::DEVICE_TYPE_DESKTOP ) ),
+			self::DEVICE_TYPE_GLOBAL  => Storage\Base::normalize_value( $this->storage->get( self::get_current_profile_id() ) ),
 		];
 		if ( OPTML_DEBUG ) {
 			do_action( 'optml_log', 'Profile data: ' . print_r( self::$current_profile_data, true ) . ' for id: ' . self::get_current_profile_id() );
@@ -361,12 +365,14 @@ class Profile {
 	 */
 	public function is_in_all_viewports( int $image_id ): bool {
 		foreach ( self::get_active_devices() as $device ) {
+			$device_data = self::get_device_data( $device );
 			// If the data is not available for the device, return false.
-			if ( empty( self::$current_profile_data[ $device ] ?? null ) ) {
+			if ( empty( $device_data ) ) {
 				return false;
 			}
 			// If the image is not in the viewport of the device, return false.
-			if ( ! ( self::$current_profile_data[ $device ]['af'][ $image_id ] ?? false ) ) {
+			$above_fold = self::get_device_member( $device, 'af' );
+			if ( empty( $above_fold[ $image_id ] ) ) {
 				return false;
 			}
 		}
@@ -384,7 +390,8 @@ class Profile {
 	 */
 	public function is_lcp_image_in_all_viewports( int $image_id ): bool {
 		foreach ( self::get_active_devices() as $device ) {
-			if ( ( ( self::$current_profile_data[ $device ]['lcp']['type'] ?? '' ) === 'img' ) && ( self::$current_profile_data[ $device ]['lcp']['imageId'] === $image_id ) ) {
+			$lcp = self::get_device_member( $device, 'lcp' );
+			if ( ( $lcp['type'] ?? '' ) === 'img' && ( $lcp['imageId'] ?? null ) === $image_id ) {
 				return true;
 			}
 		}
@@ -401,7 +408,8 @@ class Profile {
 	 */
 	public function is_in_any_viewport( $image_id ) {
 		foreach ( self::get_active_devices() as $device ) {
-			if ( self::$current_profile_data[ $device ]['af'][ $image_id ] ?? false ) {
+			$above_fold = self::get_device_member( $device, 'af' );
+			if ( ! empty( $above_fold[ $image_id ] ) ) {
 				return $device;
 			}
 		}
@@ -419,7 +427,7 @@ class Profile {
 	public function get_profile_data( $id ) {
 		$profile_data = [];
 		foreach ( self::get_active_devices() as $device ) {
-			$profile_data[ $device ] = $this->storage->get( $id . '_' . $device );
+			$profile_data[ $device ] = Storage\Base::normalize_value( $this->storage->get( $id . '_' . $device ) );
 		}
 
 		return $profile_data;
@@ -454,12 +462,45 @@ class Profile {
 	 */
 	public function is_data_available(): bool {
 		foreach ( self::get_active_devices() as $device ) {
-			if ( empty( self::$current_profile_data[ $device ] ) ) {
+			if ( empty( self::get_device_data( $device ) ) ) {
 				return false;
 			}
 		}
 
 		return true;
+	}
+
+	/**
+	 * Get array-shaped profile data for a device.
+	 *
+	 * Object-shaped cache values are coerced to arrays so viewport lookups never fatal.
+	 *
+	 * @param int $device Device type constant.
+	 * @return array<string, mixed>
+	 */
+	private static function get_device_data( int $device ): array {
+		$data = self::$current_profile_data[ $device ] ?? [];
+		if ( ! is_array( $data ) ) {
+			$data = Storage\Base::normalize_value( $data );
+		}
+
+		return is_array( $data ) ? $data : [];
+	}
+
+	/**
+	 * Get an array member from a device profile.
+	 *
+	 * @param int    $device Device type constant.
+	 * @param string $key    Member key (af, bg, lcp, m, s, c).
+	 * @return array<string|int, mixed>
+	 */
+	private static function get_device_member( int $device, string $key ): array {
+		$member = self::get_device_data( $device )[ $key ] ?? [];
+		if ( ! is_array( $member ) ) {
+			$member = Storage\Base::normalize_value( $member );
+		}
+
+		return is_array( $member ) ? $member : [];
 	}
 
 	/**

--- a/inc/v2/PageProfiler/Storage/Base.php
+++ b/inc/v2/PageProfiler/Storage/Base.php
@@ -22,9 +22,41 @@ abstract class Base {
 	 * Retrieve data by key.
 	 *
 	 * @param string $key The unique identifier for the data to retrieve.
-	 * @return array|false The stored data or null if not found.
+	 * @return array<string, mixed>|false The stored data or false if not found.
 	 */
 	abstract public function get( string $key );
+
+	/**
+	 * Coerce a stored profiler payload to an array.
+	 *
+	 * Object-cache backends that JSON-decode without associative arrays return stdClass.
+	 * Nested objects (e.g. `af`, `bg`, `lcp`) are converted recursively.
+	 *
+	 * @param mixed $value Raw storage value.
+	 * @return array<string|int, mixed>|false
+	 */
+	public static function normalize_value( $value ) {
+		if ( false === $value || null === $value ) {
+			return false;
+		}
+
+		if ( is_object( $value ) ) {
+			$value = get_object_vars( $value );
+		}
+
+		if ( ! is_array( $value ) ) {
+			return false;
+		}
+
+		foreach ( $value as $key => $item ) {
+			if ( is_object( $item ) || is_array( $item ) ) {
+				$normalized_item = self::normalize_value( $item );
+				$value[ $key ]     = ( false !== $normalized_item ) ? $normalized_item : [];
+			}
+		}
+
+		return $value;
+	}
 
 	/**
 	 * Delete data by key.

--- a/inc/v2/PageProfiler/Storage/ObjectCache.php
+++ b/inc/v2/PageProfiler/Storage/ObjectCache.php
@@ -55,10 +55,10 @@ class ObjectCache extends Base {
 	 * Retrieve data from the object cache.
 	 *
 	 * @param string $key The unique identifier for the data to retrieve.
-	 * @return array|false The stored data or false if not found.
+	 * @return array<string, mixed>|false The stored data or false if not found.
 	 */
 	public function get( string $key ) {
-		return wp_cache_get( $key, self::GROUP );
+		return self::normalize_value( wp_cache_get( $key, self::GROUP ) );
 	}
 
 	/**

--- a/inc/v2/PageProfiler/Storage/Transients.php
+++ b/inc/v2/PageProfiler/Storage/Transients.php
@@ -65,10 +65,10 @@ class Transients extends Base {
 	 * Retrieves data from a transient.
 	 *
 	 * @param string $key The key to retrieve data for.
-	 * @return mixed The stored data or false if the transient doesn't exist or has expired.
+	 * @return array<string, mixed>|false The stored data or false if the transient doesn't exist or has expired.
 	 */
 	public function get( string $key ) {
-		return get_transient( $this->get_key( $key ) );
+		return self::normalize_value( get_transient( $this->get_key( $key ) ) );
 	}
 
 	/**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3073,12 +3073,6 @@ parameters:
 			path: inc/v2/PageProfiler/Storage/Base.php
 
 		-
-			message: '#^Method OptimoleWP\\PageProfiler\\Storage\\Base\:\:get\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: inc/v2/PageProfiler/Storage/Base.php
-
-		-
 			message: '#^Method OptimoleWP\\PageProfiler\\Storage\\Base\:\:store\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -3089,12 +3083,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: inc/v2/PageProfiler/Storage/Base.php
-
-		-
-			message: '#^Method OptimoleWP\\PageProfiler\\Storage\\ObjectCache\:\:get\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: inc/v2/PageProfiler/Storage/ObjectCache.php
 
 		-
 			message: '#^Method OptimoleWP\\PageProfiler\\Storage\\ObjectCache\:\:store\(\) has parameter \$data with no value type specified in iterable type array\.$#'

--- a/tests/test-page-profiler-shape.php
+++ b/tests/test-page-profiler-shape.php
@@ -88,24 +88,28 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Inject current profile data, including object-shaped values.
+	 * Seed transients with object-shaped payloads and load them through storage.
 	 *
-	 * @param mixed $mobile  Mobile payload.
-	 * @param mixed $desktop Desktop payload.
-	 * @param mixed $global  Global payload.
+	 * @param mixed $mobile  Mobile payload, or false to skip.
+	 * @param mixed $desktop Desktop payload, or false to skip.
+	 * @param mixed $global  Global payload, or false to skip.
+	 * @return string Profile ID.
 	 */
-	private function injectCurrentProfileData( $mobile, $desktop, $global = false ) {
-		$reflection = new ReflectionClass( Profile::class );
-		$property     = $reflection->getProperty( 'current_profile_data' );
-		$property->setAccessible( true );
-		$property->setValue(
-			null,
-			[
-				Profile::DEVICE_TYPE_MOBILE  => $mobile,
-				Profile::DEVICE_TYPE_DESKTOP => $desktop,
-				Profile::DEVICE_TYPE_GLOBAL  => $global,
-			]
-		);
+	private function loadProfileFromStorage( $mobile, $desktop, $global = false ) {
+		$profile_id = 'shape_' . wp_generate_uuid4();
+		if ( false !== $mobile ) {
+			set_transient( Transients::PREFIX . $profile_id . '_' . Profile::DEVICE_TYPE_MOBILE, $mobile, HOUR_IN_SECONDS );
+		}
+		if ( false !== $desktop ) {
+			set_transient( Transients::PREFIX . $profile_id . '_' . Profile::DEVICE_TYPE_DESKTOP, $desktop, HOUR_IN_SECONDS );
+		}
+		if ( false !== $global ) {
+			set_transient( Transients::PREFIX . $profile_id, $global, HOUR_IN_SECONDS );
+		}
+		Profile::reset_current_profile();
+		Profile::set_current_profile_id( $profile_id );
+		Optml_Manager::instance()->page_profiler->set_current_profile_data();
+		return $profile_id;
 	}
 
 	/**
@@ -140,7 +144,7 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 	 * Nested stdClass trees become associative arrays, including numeric keys.
 	 */
 	public function test_normalize_value_converts_nested_stdclass() {
-		$object   = $this->objectProfile();
+		$object     = $this->objectProfile();
 		$normalized = ProfilerStorage::normalize_value( $object );
 
 		$this->assertIsArray( $normalized );
@@ -156,7 +160,7 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 	 * Top-level array with object-shaped members is still coerced.
 	 */
 	public function test_normalize_value_converts_object_members_inside_array() {
-		$payload = [
+		$payload    = [
 			'af'  => (object) [ (string) self::ABOVE_FOLD_IMAGE_ID => true ],
 			'bg'  => (object) [],
 			'lcp' => (object) [ 'type' => 'img', 'imageId' => self::ABOVE_FOLD_IMAGE_ID ],
@@ -238,7 +242,7 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 	 * The reported crash: indexing object-shaped device data as an array.
 	 */
 	public function test_is_in_all_viewports_does_not_fatal_on_stdclass() {
-		$this->injectCurrentProfileData( $this->objectProfile(), $this->objectProfile() );
+		$this->loadProfileFromStorage( $this->objectProfile(), $this->objectProfile() );
 		$profiler = Optml_Manager::instance()->page_profiler;
 
 		$this->assertTrue( $profiler->is_in_all_viewports( self::ABOVE_FOLD_IMAGE_ID ) );
@@ -249,11 +253,11 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 	 * Object-shaped above-fold map only (array wrapper, object `af`).
 	 */
 	public function test_is_in_all_viewports_with_object_shaped_af_member() {
-		$mobile  = $this->arrayProfile();
-		$desktop = $this->arrayProfile();
+		$mobile        = $this->arrayProfile();
+		$desktop       = $this->arrayProfile();
 		$mobile['af']  = (object) [ (string) self::ABOVE_FOLD_IMAGE_ID => true ];
 		$desktop['af'] = (object) [ (string) self::ABOVE_FOLD_IMAGE_ID => true ];
-		$this->injectCurrentProfileData( $mobile, $desktop );
+		$this->loadProfileFromStorage( $mobile, $desktop );
 		$profiler = Optml_Manager::instance()->page_profiler;
 
 		$this->assertTrue( $profiler->is_in_all_viewports( self::ABOVE_FOLD_IMAGE_ID ) );
@@ -263,7 +267,7 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 	 * Missing or empty object-shaped device data is treated as unavailable.
 	 */
 	public function test_is_in_all_viewports_empty_object_is_unavailable() {
-		$this->injectCurrentProfileData( new stdClass(), $this->objectProfile() );
+		$this->loadProfileFromStorage( new stdClass(), $this->objectProfile() );
 		$profiler = Optml_Manager::instance()->page_profiler;
 
 		$this->assertFalse( $profiler->is_in_all_viewports( self::ABOVE_FOLD_IMAGE_ID ) );
@@ -274,7 +278,7 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 	 * is_in_any_viewport must not fatal on object-shaped data.
 	 */
 	public function test_is_in_any_viewport_does_not_fatal_on_stdclass() {
-		$this->injectCurrentProfileData( $this->objectProfile(), false );
+		$this->loadProfileFromStorage( $this->objectProfile(), $this->objectProfile() );
 		$profiler = Optml_Manager::instance()->page_profiler;
 
 		$this->assertSame( Profile::DEVICE_TYPE_MOBILE, $profiler->is_in_any_viewport( self::ABOVE_FOLD_IMAGE_ID ) );
@@ -285,11 +289,23 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 	 * LCP lookup must not fatal on object-shaped `lcp`.
 	 */
 	public function test_is_lcp_image_in_all_viewports_does_not_fatal_on_stdclass() {
-		$this->injectCurrentProfileData( $this->objectProfile(), $this->objectProfile() );
+		$this->loadProfileFromStorage( $this->objectProfile(), $this->objectProfile() );
 		$profiler = Optml_Manager::instance()->page_profiler;
 
 		$this->assertTrue( $profiler->is_lcp_image_in_all_viewports( self::ABOVE_FOLD_IMAGE_ID ) );
 		$this->assertFalse( $profiler->is_lcp_image_in_all_viewports( self::OTHER_IMAGE_ID ) );
+	}
+
+	/**
+	 * Missing LCP imageId must not warn or fatal.
+	 */
+	public function test_is_lcp_image_handles_missing_image_id() {
+		$payload        = $this->arrayProfile();
+		$payload['lcp'] = [ 'type' => 'img' ];
+		$this->loadProfileFromStorage( $payload, $payload );
+		$profiler = Optml_Manager::instance()->page_profiler;
+
+		$this->assertFalse( $profiler->is_lcp_image_in_all_viewports( self::ABOVE_FOLD_IMAGE_ID ) );
 	}
 
 	/**
@@ -313,7 +329,7 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 			],
 			'c' => (object) [ (string) self::ABOVE_FOLD_IMAGE_ID => true ],
 		];
-		$this->injectCurrentProfileData( false, false, $global );
+		$this->loadProfileFromStorage( $this->objectProfile(), $this->objectProfile(), $global );
 		$profiler = Optml_Manager::instance()->page_profiler;
 
 		$this->assertSame( [ 'w' => 100, 'h' => 80 ], $profiler->get_missing_dimensions( self::ABOVE_FOLD_IMAGE_ID ) );
@@ -327,22 +343,14 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 	 * Loading current profile data from object-shaped transients yields arrays.
 	 */
 	public function test_set_current_profile_data_normalizes_transients() {
-		$profile_id = 'shape_load_' . wp_generate_uuid4();
-		foreach ( Profile::get_active_devices() as $device ) {
-			set_transient(
-				Transients::PREFIX . $profile_id . '_' . $device,
-				$this->objectProfile(),
-				HOUR_IN_SECONDS
-			);
-		}
-
-		Profile::set_current_profile_id( $profile_id );
-		$data = Optml_Manager::instance()->page_profiler->set_current_profile_data();
+		$this->loadProfileFromStorage( $this->objectProfile(), $this->objectProfile() );
+		$data     = Profile::get_current_profile_data();
+		$profiler = Optml_Manager::instance()->page_profiler;
 
 		$this->assertIsArray( $data[ Profile::DEVICE_TYPE_MOBILE ] );
 		$this->assertIsArray( $data[ Profile::DEVICE_TYPE_DESKTOP ] );
 		$this->assertTrue( $data[ Profile::DEVICE_TYPE_MOBILE ]['af'][ self::ABOVE_FOLD_IMAGE_ID ] );
-		$this->assertTrue( Optml_Manager::instance()->page_profiler->is_in_all_viewports( self::ABOVE_FOLD_IMAGE_ID ) );
+		$this->assertTrue( $profiler->is_in_all_viewports( self::ABOVE_FOLD_IMAGE_ID ) );
 	}
 
 	/**
@@ -365,9 +373,9 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 	 * exists() is true after object-shaped data is normalized, false for scalars.
 	 */
 	public function test_exists_with_object_shaped_and_corrupt_storage() {
-		$profiler   = Optml_Manager::instance()->page_profiler;
-		$good_id    = 'shape_exists_good_' . wp_generate_uuid4();
-		$bad_id     = 'shape_exists_bad_' . wp_generate_uuid4();
+		$profiler = Optml_Manager::instance()->page_profiler;
+		$good_id  = 'shape_exists_good_' . wp_generate_uuid4();
+		$bad_id   = 'shape_exists_bad_' . wp_generate_uuid4();
 
 		set_transient(
 			Transients::PREFIX . $good_id . '_' . Profile::DEVICE_TYPE_DESKTOP,
@@ -386,15 +394,12 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Personalized background CSS must not fatal on object-shaped profile data.
+	 * Personalized background CSS must not fatal when current profile came from stdClass storage.
 	 */
 	public function test_personalized_css_does_not_fatal_on_stdclass() {
-		$data = [
-			Profile::DEVICE_TYPE_MOBILE  => $this->objectProfile(),
-			Profile::DEVICE_TYPE_DESKTOP => $this->objectProfile(),
-		];
+		$this->loadProfileFromStorage( $this->objectProfile(), $this->objectProfile() );
 
-		$css = Lazyload::get_personalized_css( $data );
+		$css = Lazyload::get_current_personalized_css();
 		$this->assertIsString( $css );
 	}
 
@@ -402,21 +407,13 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 	 * Frontend HTML replacement must not fatal when transients hold stdClass profiles.
 	 */
 	public function test_replace_content_does_not_fatal_on_object_shaped_profile() {
-		$profile_id = 'shape_html_' . wp_generate_uuid4();
+		$profile_id = $this->loadProfileFromStorage( $this->objectProfile(), $this->objectProfile() );
 		add_filter(
 			'optml_page_profile_id',
 			function () use ( $profile_id ) {
 				return $profile_id;
 			}
 		);
-
-		foreach ( Profile::get_active_devices() as $device ) {
-			set_transient(
-				Transients::PREFIX . $profile_id . '_' . $device,
-				$this->objectProfile(),
-				HOUR_IN_SECONDS
-			);
-		}
 
 		$html = Optml_Manager::instance()->replace_content( Test_Lazyload_Viewport::get_sample_html() );
 		$this->assertNotEmpty( $html );
@@ -429,8 +426,7 @@ class Test_Page_Profiler_Shape extends WP_UnitTestCase {
 	 * can_lazyload_for() uses the viewport lookup and must not fatal.
 	 */
 	public function test_can_lazyload_for_does_not_fatal_on_stdclass() {
-		$this->injectCurrentProfileData( $this->objectProfile(), $this->objectProfile() );
-		Profile::set_current_profile_id( 'shape_can_lazy' );
+		$this->loadProfileFromStorage( $this->objectProfile(), $this->objectProfile() );
 
 		$replacer = Optml_Lazyload_Replacer::instance();
 		$url      = 'https://example.com/test-image.jpg';

--- a/tests/test-page-profiler-shape.php
+++ b/tests/test-page-profiler-shape.php
@@ -1,0 +1,441 @@
+<?php
+/**
+ * Tests for object-shaped page-profiler storage values.
+ *
+ * @package Optimole-WP
+ */
+
+use OptimoleWP\BgOptimizer\Lazyload;
+use OptimoleWP\PageProfiler\Profile;
+use OptimoleWP\PageProfiler\Storage\Base as ProfilerStorage;
+use OptimoleWP\PageProfiler\Storage\ObjectCache;
+use OptimoleWP\PageProfiler\Storage\Transients;
+
+/**
+ * Class Test_Page_Profiler_Shape.
+ */
+class Test_Page_Profiler_Shape extends WP_UnitTestCase {
+	const ABOVE_FOLD_IMAGE_ID = 1579989818;
+	const OTHER_IMAGE_ID = 9999999;
+
+	/**
+	 * Set up the test environment before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$settings = new Optml_Settings();
+		$settings->update(
+			'service_data',
+			[
+				'cdn_key'    => 'test123',
+				'cdn_secret' => '12345',
+				'whitelist'  => [ 'example.com' ],
+			]
+		);
+		$settings->update( 'lazyload', 'enabled' );
+		$settings->update( 'lazyload_type', 'viewport' );
+		Optml_Url_Replacer::instance()->init();
+		Optml_Tag_Replacer::instance()->init();
+		Optml_Lazyload_Replacer::instance()->init();
+		Optml_Manager::instance()->init();
+		Profile::reset_current_profile();
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		Profile::reset_current_profile();
+		wp_cache_flush();
+	}
+
+	/**
+	 * Build a valid device profile payload as an array.
+	 *
+	 * @param array $overrides Optional overrides.
+	 * @return array
+	 */
+	private function arrayProfile( $overrides = [] ) {
+		return array_merge(
+			[
+				'af'  => [ self::ABOVE_FOLD_IMAGE_ID => true ],
+				'bg'  => [
+					'[style*="background-image:url("]' => [
+						'.hero' => [ 'https://example.com/bg.jpg' ],
+					],
+				],
+				'lcp' => [
+					'type'    => 'img',
+					'imageId' => self::ABOVE_FOLD_IMAGE_ID,
+				],
+			],
+			$overrides
+		);
+	}
+
+	/**
+	 * JSON-decode a payload without associative arrays (Redis/JSON object-cache shape).
+	 *
+	 * @param array $payload Array payload.
+	 * @return object
+	 */
+	private function objectProfile( $payload = null ) {
+		if ( null === $payload ) {
+			$payload = $this->arrayProfile();
+		}
+		return json_decode( wp_json_encode( $payload ) );
+	}
+
+	/**
+	 * Inject current profile data, including object-shaped values.
+	 *
+	 * @param mixed $mobile  Mobile payload.
+	 * @param mixed $desktop Desktop payload.
+	 * @param mixed $global  Global payload.
+	 */
+	private function injectCurrentProfileData( $mobile, $desktop, $global = false ) {
+		$reflection = new ReflectionClass( Profile::class );
+		$property     = $reflection->getProperty( 'current_profile_data' );
+		$property->setAccessible( true );
+		$property->setValue(
+			null,
+			[
+				Profile::DEVICE_TYPE_MOBILE  => $mobile,
+				Profile::DEVICE_TYPE_DESKTOP => $desktop,
+				Profile::DEVICE_TYPE_GLOBAL  => $global,
+			]
+		);
+	}
+
+	/**
+	 * @dataProvider normalizeValueProvider
+	 * @param mixed $input    Raw value.
+	 * @param mixed $expected Expected normalize result.
+	 */
+	public function test_normalize_value( $input, $expected ) {
+		$this->assertSame( $expected, ProfilerStorage::normalize_value( $input ) );
+	}
+
+	/**
+	 * Data provider for normalize_value.
+	 *
+	 * @return array
+	 */
+	public function normalizeValueProvider() {
+		return [
+			'false'        => [ false, false ],
+			'null'         => [ null, false ],
+			'string'       => [ 'corrupt', false ],
+			'integer'      => [ 0, false ],
+			'empty_array'  => [ [], [] ],
+			'flat_array'   => [
+				[ 'af' => [ 1 => true ] ],
+				[ 'af' => [ 1 => true ] ],
+			],
+		];
+	}
+
+	/**
+	 * Nested stdClass trees become associative arrays, including numeric keys.
+	 */
+	public function test_normalize_value_converts_nested_stdclass() {
+		$object   = $this->objectProfile();
+		$normalized = ProfilerStorage::normalize_value( $object );
+
+		$this->assertIsArray( $normalized );
+		$this->assertIsArray( $normalized['af'] );
+		$this->assertTrue( $normalized['af'][ self::ABOVE_FOLD_IMAGE_ID ] );
+		$this->assertIsArray( $normalized['bg'] );
+		$this->assertIsArray( $normalized['lcp'] );
+		$this->assertSame( 'img', $normalized['lcp']['type'] );
+		$this->assertSame( self::ABOVE_FOLD_IMAGE_ID, $normalized['lcp']['imageId'] );
+	}
+
+	/**
+	 * Top-level array with object-shaped members is still coerced.
+	 */
+	public function test_normalize_value_converts_object_members_inside_array() {
+		$payload = [
+			'af'  => (object) [ (string) self::ABOVE_FOLD_IMAGE_ID => true ],
+			'bg'  => (object) [],
+			'lcp' => (object) [ 'type' => 'img', 'imageId' => self::ABOVE_FOLD_IMAGE_ID ],
+		];
+		$normalized = ProfilerStorage::normalize_value( $payload );
+
+		$this->assertIsArray( $normalized['af'] );
+		$this->assertTrue( ! empty( $normalized['af'][ self::ABOVE_FOLD_IMAGE_ID ] ) );
+		$this->assertIsArray( $normalized['lcp'] );
+		$this->assertSame( 'img', $normalized['lcp']['type'] );
+	}
+
+	/**
+	 * Object cache get() returns arrays when the backend stored stdClass.
+	 */
+	public function test_object_cache_get_normalizes_stdclass() {
+		$storage = new ObjectCache();
+		$key     = 'shape_oc_' . wp_generate_uuid4();
+		wp_cache_set( $key, $this->objectProfile(), ObjectCache::GROUP );
+
+		$retrieved = $storage->get( $key );
+		$this->assertIsArray( $retrieved );
+		$this->assertTrue( $retrieved['af'][ self::ABOVE_FOLD_IMAGE_ID ] );
+	}
+
+	/**
+	 * Object cache miss stays false.
+	 */
+	public function test_object_cache_get_miss_returns_false() {
+		$storage = new ObjectCache();
+		$this->assertFalse( $storage->get( 'missing_profiler_key_' . wp_generate_uuid4() ) );
+	}
+
+	/**
+	 * Object cache still returns stored arrays unchanged.
+	 */
+	public function test_object_cache_get_preserves_arrays() {
+		$storage = new ObjectCache();
+		$key     = 'shape_oc_array_' . wp_generate_uuid4();
+		$payload = $this->arrayProfile();
+		$storage->store( $key, $payload );
+
+		$this->assertSame( $payload, $storage->get( $key ) );
+	}
+
+	/**
+	 * Corrupt object-cache values are treated as a miss.
+	 */
+	public function test_object_cache_get_rejects_scalars() {
+		$storage = new ObjectCache();
+		$key     = 'shape_oc_bad_' . wp_generate_uuid4();
+		wp_cache_set( $key, 'not-a-profile', ObjectCache::GROUP );
+
+		$this->assertFalse( $storage->get( $key ) );
+	}
+
+	/**
+	 * Transient get() returns arrays when the stored value is stdClass.
+	 */
+	public function test_transients_get_normalizes_stdclass() {
+		$storage = new Transients();
+		$key     = 'shape_tr_' . wp_generate_uuid4();
+		set_transient( Transients::PREFIX . $key, $this->objectProfile(), HOUR_IN_SECONDS );
+
+		$retrieved = $storage->get( $key );
+		$this->assertIsArray( $retrieved );
+		$this->assertTrue( $retrieved['af'][ self::ABOVE_FOLD_IMAGE_ID ] );
+	}
+
+	/**
+	 * Transient miss stays false.
+	 */
+	public function test_transients_get_miss_returns_false() {
+		$storage = new Transients();
+		$this->assertFalse( $storage->get( 'missing_transient_' . wp_generate_uuid4() ) );
+	}
+
+	/**
+	 * The reported crash: indexing object-shaped device data as an array.
+	 */
+	public function test_is_in_all_viewports_does_not_fatal_on_stdclass() {
+		$this->injectCurrentProfileData( $this->objectProfile(), $this->objectProfile() );
+		$profiler = Optml_Manager::instance()->page_profiler;
+
+		$this->assertTrue( $profiler->is_in_all_viewports( self::ABOVE_FOLD_IMAGE_ID ) );
+		$this->assertFalse( $profiler->is_in_all_viewports( self::OTHER_IMAGE_ID ) );
+	}
+
+	/**
+	 * Object-shaped above-fold map only (array wrapper, object `af`).
+	 */
+	public function test_is_in_all_viewports_with_object_shaped_af_member() {
+		$mobile  = $this->arrayProfile();
+		$desktop = $this->arrayProfile();
+		$mobile['af']  = (object) [ (string) self::ABOVE_FOLD_IMAGE_ID => true ];
+		$desktop['af'] = (object) [ (string) self::ABOVE_FOLD_IMAGE_ID => true ];
+		$this->injectCurrentProfileData( $mobile, $desktop );
+		$profiler = Optml_Manager::instance()->page_profiler;
+
+		$this->assertTrue( $profiler->is_in_all_viewports( self::ABOVE_FOLD_IMAGE_ID ) );
+	}
+
+	/**
+	 * Missing or empty object-shaped device data is treated as unavailable.
+	 */
+	public function test_is_in_all_viewports_empty_object_is_unavailable() {
+		$this->injectCurrentProfileData( new stdClass(), $this->objectProfile() );
+		$profiler = Optml_Manager::instance()->page_profiler;
+
+		$this->assertFalse( $profiler->is_in_all_viewports( self::ABOVE_FOLD_IMAGE_ID ) );
+		$this->assertFalse( $profiler->is_data_available() );
+	}
+
+	/**
+	 * is_in_any_viewport must not fatal on object-shaped data.
+	 */
+	public function test_is_in_any_viewport_does_not_fatal_on_stdclass() {
+		$this->injectCurrentProfileData( $this->objectProfile(), false );
+		$profiler = Optml_Manager::instance()->page_profiler;
+
+		$this->assertSame( Profile::DEVICE_TYPE_MOBILE, $profiler->is_in_any_viewport( self::ABOVE_FOLD_IMAGE_ID ) );
+		$this->assertFalse( $profiler->is_in_any_viewport( self::OTHER_IMAGE_ID ) );
+	}
+
+	/**
+	 * LCP lookup must not fatal on object-shaped `lcp`.
+	 */
+	public function test_is_lcp_image_in_all_viewports_does_not_fatal_on_stdclass() {
+		$this->injectCurrentProfileData( $this->objectProfile(), $this->objectProfile() );
+		$profiler = Optml_Manager::instance()->page_profiler;
+
+		$this->assertTrue( $profiler->is_lcp_image_in_all_viewports( self::ABOVE_FOLD_IMAGE_ID ) );
+		$this->assertFalse( $profiler->is_lcp_image_in_all_viewports( self::OTHER_IMAGE_ID ) );
+	}
+
+	/**
+	 * Global missing-dimension lookups must not fatal on object-shaped global data.
+	 */
+	public function test_global_lookups_do_not_fatal_on_stdclass() {
+		$global = (object) [
+			'm' => (object) [
+				(string) self::ABOVE_FOLD_IMAGE_ID => (object) [ 'w' => 100, 'h' => 80 ],
+			],
+			's' => (object) [
+				(string) self::ABOVE_FOLD_IMAGE_ID => (object) [
+					'200' => (object) [
+						'w' => 200,
+						'h' => 160,
+						'd' => 1,
+						's' => 'https://example.com/i.jpg',
+						'b' => 1,
+					],
+				],
+			],
+			'c' => (object) [ (string) self::ABOVE_FOLD_IMAGE_ID => true ],
+		];
+		$this->injectCurrentProfileData( false, false, $global );
+		$profiler = Optml_Manager::instance()->page_profiler;
+
+		$this->assertSame( [ 'w' => 100, 'h' => 80 ], $profiler->get_missing_dimensions( self::ABOVE_FOLD_IMAGE_ID ) );
+		$this->assertSame( [], $profiler->get_missing_dimensions( self::OTHER_IMAGE_ID ) );
+		$this->assertNotEmpty( $profiler->get_missing_srcsets( self::ABOVE_FOLD_IMAGE_ID ) );
+		$this->assertTrue( $profiler->get_crop_status( self::ABOVE_FOLD_IMAGE_ID ) );
+		$this->assertFalse( $profiler->get_crop_status( self::OTHER_IMAGE_ID ) );
+	}
+
+	/**
+	 * Loading current profile data from object-shaped transients yields arrays.
+	 */
+	public function test_set_current_profile_data_normalizes_transients() {
+		$profile_id = 'shape_load_' . wp_generate_uuid4();
+		foreach ( Profile::get_active_devices() as $device ) {
+			set_transient(
+				Transients::PREFIX . $profile_id . '_' . $device,
+				$this->objectProfile(),
+				HOUR_IN_SECONDS
+			);
+		}
+
+		Profile::set_current_profile_id( $profile_id );
+		$data = Optml_Manager::instance()->page_profiler->set_current_profile_data();
+
+		$this->assertIsArray( $data[ Profile::DEVICE_TYPE_MOBILE ] );
+		$this->assertIsArray( $data[ Profile::DEVICE_TYPE_DESKTOP ] );
+		$this->assertTrue( $data[ Profile::DEVICE_TYPE_MOBILE ]['af'][ self::ABOVE_FOLD_IMAGE_ID ] );
+		$this->assertTrue( Optml_Manager::instance()->page_profiler->is_in_all_viewports( self::ABOVE_FOLD_IMAGE_ID ) );
+	}
+
+	/**
+	 * get_profile_data() also normalizes object-shaped storage.
+	 */
+	public function test_get_profile_data_normalizes_stdclass() {
+		$profile_id = 'shape_get_' . wp_generate_uuid4();
+		set_transient(
+			Transients::PREFIX . $profile_id . '_' . Profile::DEVICE_TYPE_DESKTOP,
+			$this->objectProfile(),
+			HOUR_IN_SECONDS
+		);
+
+		$data = Optml_Manager::instance()->page_profiler->get_profile_data( $profile_id );
+		$this->assertIsArray( $data[ Profile::DEVICE_TYPE_DESKTOP ] );
+		$this->assertTrue( $data[ Profile::DEVICE_TYPE_DESKTOP ]['af'][ self::ABOVE_FOLD_IMAGE_ID ] );
+	}
+
+	/**
+	 * exists() is true after object-shaped data is normalized, false for scalars.
+	 */
+	public function test_exists_with_object_shaped_and_corrupt_storage() {
+		$profiler   = Optml_Manager::instance()->page_profiler;
+		$good_id    = 'shape_exists_good_' . wp_generate_uuid4();
+		$bad_id     = 'shape_exists_bad_' . wp_generate_uuid4();
+
+		set_transient(
+			Transients::PREFIX . $good_id . '_' . Profile::DEVICE_TYPE_DESKTOP,
+			$this->objectProfile(),
+			HOUR_IN_SECONDS
+		);
+		set_transient(
+			Transients::PREFIX . $bad_id . '_' . Profile::DEVICE_TYPE_DESKTOP,
+			'nope',
+			HOUR_IN_SECONDS
+		);
+
+		$this->assertTrue( $profiler->exists( $good_id, Profile::DEVICE_TYPE_DESKTOP ) );
+		$this->assertFalse( $profiler->exists( $bad_id, Profile::DEVICE_TYPE_DESKTOP ) );
+		$this->assertFalse( $profiler->exists_all( $good_id ) );
+	}
+
+	/**
+	 * Personalized background CSS must not fatal on object-shaped profile data.
+	 */
+	public function test_personalized_css_does_not_fatal_on_stdclass() {
+		$data = [
+			Profile::DEVICE_TYPE_MOBILE  => $this->objectProfile(),
+			Profile::DEVICE_TYPE_DESKTOP => $this->objectProfile(),
+		];
+
+		$css = Lazyload::get_personalized_css( $data );
+		$this->assertIsString( $css );
+	}
+
+	/**
+	 * Frontend HTML replacement must not fatal when transients hold stdClass profiles.
+	 */
+	public function test_replace_content_does_not_fatal_on_object_shaped_profile() {
+		$profile_id = 'shape_html_' . wp_generate_uuid4();
+		add_filter(
+			'optml_page_profile_id',
+			function () use ( $profile_id ) {
+				return $profile_id;
+			}
+		);
+
+		foreach ( Profile::get_active_devices() as $device ) {
+			set_transient(
+				Transients::PREFIX . $profile_id . '_' . $device,
+				$this->objectProfile(),
+				HOUR_IN_SECONDS
+			);
+		}
+
+		$html = Optml_Manager::instance()->replace_content( Test_Lazyload_Viewport::get_sample_html() );
+		$this->assertNotEmpty( $html );
+		$this->assertStringContainsString( '<img', $html );
+
+		remove_all_filters( 'optml_page_profile_id' );
+	}
+
+	/**
+	 * can_lazyload_for() uses the viewport lookup and must not fatal.
+	 */
+	public function test_can_lazyload_for_does_not_fatal_on_stdclass() {
+		$this->injectCurrentProfileData( $this->objectProfile(), $this->objectProfile() );
+		Profile::set_current_profile_id( 'shape_can_lazy' );
+
+		$replacer = Optml_Lazyload_Replacer::instance();
+		$url      = 'https://example.com/test-image.jpg';
+		$tag      = '<img src="' . $url . '" alt="test">';
+
+		$this->assertIsBool( $replacer->can_lazyload_for( $url, $tag ) );
+	}
+}


### PR DESCRIPTION
## Summary
- Viewport lazyload fatals when stored page-profile data is `stdClass` instead of an array (`Cannot use object of type stdClass as array` at `Profile.php:369`). That is the usual shape when an object-cache backend JSON-decodes without associative arrays.
- Normalize storage `get()` through `Storage\Base::normalize_value()`, coerce again when loading current profile data, and guard `af`/`lcp`/global lookups plus personalized background CSS so a bad shape never 500s the frontend.
- Valid object-shaped payloads are converted and still used (above-fold detection keeps working); corrupt scalars are treated as a cache miss.

Fixes #1122

## Test plan
- [x] `composer phpunit -- --filter='Test_Page_Profiler_Shape|Test_Lazyload_Viewport'` (42 tests)
- [x] PHPCS and PHPStan on the changed v2 files
- [ ] Confirm a Redis/Memcached drop-in that JSON-decodes objects no longer fatals frontend viewport lazyload
- [ ] With viewport lazyload on, a page with stored profile data still skips above-fold images after an object-cache roundtrip
- [ ] Missing/corrupt cache values still fall back to lazyloading all images


Made with [Cursor](https://cursor.com)