### PR TITLE
fix: skip temporary Cache-Control header on non-cacheable pages

### DIFF
--- a/inc/manager.php
+++ b/inc/manager.php
@@ -430,6 +430,48 @@ final class Optml_Manager {
 	public static function should_load_profiler( $default_value = false ) {
 		return ! $default_value && apply_filters( 'optml_page_profiler_disable', false ) === false;
 	}
+
+	/**
+	 * Decide if the temporary Cache-Control header can be sent while page profiling is pending.
+	 *
+	 * The header must never be sent on non-cacheable pages: it would replace a
+	 * Cache-Control header already set by WordPress or another plugin (PHP's
+	 * header() replaces same-name headers by default), e.g. WooCommerce's
+	 * no-cache header on cart and checkout, letting proxies cache user-specific
+	 * pages. We back off when DONOTCACHEPAGE is set or when any Cache-Control
+	 * header exists already, and let developers override the decision.
+	 *
+	 * @param array<int, string>|null $sent_headers Headers already set for the response; defaults to headers_list().
+	 * @param bool|null               $do_not_cache Whether the page is flagged as non-cacheable; defaults to the DONOTCACHEPAGE constant.
+	 *
+	 * @return bool Whether the header can be sent.
+	 */
+	public function should_send_temporary_cache_header( $sent_headers = null, $do_not_cache = null ) {
+		if ( null === $do_not_cache ) {
+			$do_not_cache = defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE;
+		}
+		$send = ! $do_not_cache;
+
+		if ( $send ) {
+			if ( null === $sent_headers ) {
+				$sent_headers = headers_list();
+			}
+			foreach ( $sent_headers as $header ) {
+				if ( stripos( $header, 'cache-control:' ) === 0 ) {
+					$send = false;
+					break;
+				}
+			}
+		}
+
+		/**
+		 * Filters whether the temporary `Cache-Control: max-age=300` header is sent
+		 * while page profiling is pending for the current page.
+		 *
+		 * @param bool $send Computed decision: false when DONOTCACHEPAGE is set or a Cache-Control header exists already.
+		 */
+		return apply_filters( 'optml_send_temporary_cache_header', $send ) === true;
+	}
 	/**
 	 * Filter raw HTML content for urls.
 	 *
@@ -461,7 +503,7 @@ final class Optml_Manager {
 						$js_optimizer
 					);
 					$html = str_replace( Optml_Admin::get_optimizer_script( true ), $js_optimizer, $html );
-					if ( ! headers_sent() ) {
+					if ( ! headers_sent() && $this->should_send_temporary_cache_header() ) {
 						header( 'Cache-Control: max-age=300' ); // Attempt to cache the page just for 5 mins until the optimizer is done. Once the optimizer is done, the page will load optimized.
 					}
 				} else {

--- a/tests/test-cache-header.php
+++ b/tests/test-cache-header.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * WordPress unit tests for the temporary Cache-Control header decision.
+ *
+ * @package     Optimole-WP
+ * @subpackage  Tests
+ * @copyright   Copyright (c) 2026, ThemeIsle
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class Test_Cache_Header.
+ */
+class Test_Cache_Header extends WP_UnitTestCase {
+
+	/**
+	 * With no signals against it, the header is sent.
+	 */
+	public function test_sends_by_default() {
+		$manager = Optml_Manager::instance();
+		$this->assertTrue( $manager->should_send_temporary_cache_header( [], false ) );
+	}
+
+	/**
+	 * Unrelated headers do not block it.
+	 */
+	public function test_unrelated_headers_do_not_block() {
+		$manager = Optml_Manager::instance();
+		$headers = [
+			'Content-Type: text/html; charset=UTF-8',
+			'X-Pingback: http://example.org/xmlrpc.php',
+			'Pragma: no-cache',
+		];
+		$this->assertTrue( $manager->should_send_temporary_cache_header( $headers, false ) );
+	}
+
+	/**
+	 * An existing Cache-Control header is never overridden, e.g. WooCommerce's
+	 * nocache_headers() output on cart and checkout pages.
+	 */
+	public function test_existing_cache_control_blocks() {
+		$manager = Optml_Manager::instance();
+		$headers = [
+			'Expires: Wed, 11 Jan 1984 05:00:00 GMT',
+			'Cache-Control: no-cache, must-revalidate, max-age=0',
+		];
+		$this->assertFalse( $manager->should_send_temporary_cache_header( $headers, false ) );
+	}
+
+	/**
+	 * The Cache-Control match is case-insensitive and value-agnostic — a longer
+	 * max-age set by a cache plugin must not be downgraded either.
+	 */
+	public function test_existing_cache_control_case_and_value_agnostic() {
+		$manager = Optml_Manager::instance();
+		$this->assertFalse( $manager->should_send_temporary_cache_header( [ 'cache-control: public, max-age=31536000' ], false ) );
+	}
+
+	/**
+	 * DONOTCACHEPAGE blocks the header.
+	 */
+	public function test_donotcachepage_blocks() {
+		$manager = Optml_Manager::instance();
+		$this->assertFalse( $manager->should_send_temporary_cache_header( [], true ) );
+	}
+
+	/**
+	 * The filter can force the header off.
+	 */
+	public function test_filter_can_disable() {
+		add_filter( 'optml_send_temporary_cache_header', '__return_false' );
+		$manager = Optml_Manager::instance();
+		$this->assertFalse( $manager->should_send_temporary_cache_header( [], false ) );
+	}
+
+	/**
+	 * The filter can force the header on despite blocking signals.
+	 */
+	public function test_filter_can_force_enable() {
+		add_filter( 'optml_send_temporary_cache_header', '__return_true' );
+		$manager = Optml_Manager::instance();
+		$this->assertTrue( $manager->should_send_temporary_cache_header( [ 'Cache-Control: no-cache' ], true ) );
+	}
+
+	/**
+	 * A non-boolean filter return does not accidentally enable the header.
+	 */
+	public function test_non_boolean_filter_return_is_not_true() {
+		add_filter(
+			'optml_send_temporary_cache_header',
+			function () {
+				return 'yes';
+			}
+		);
+		$manager = Optml_Manager::instance();
+		$this->assertFalse( $manager->should_send_temporary_cache_header( [], false ) );
+	}
+}


### PR DESCRIPTION
While page profiling was pending, Optimole sent `Cache-Control: max-age=300` on every not-logged-in request, and PHP's `header()` replaced the no-cache header WooCommerce sets on cart and checkout — so proxies could cache user-specific pages for five minutes ([issue #1082](https://github.com/Codeinwp/optimole-wp/issues/1082)). The header is now sent only when the page carries no signal against caching.

### What changed

- **`should_send_temporary_cache_header()`** — new decision guard in `Optml_Manager`. The header is skipped when `DONOTCACHEPAGE` is set, or when any `Cache-Control` header exists already.

- **Never override, never downgrade** — before: the header replaced whatever `Cache-Control` was set, including WooCommerce's `no-cache, must-revalidate, max-age=0` and longer-lived policies from cache plugins. After: an existing `Cache-Control` header always wins.

- **`optml_send_temporary_cache_header` filter** — receives the computed decision; developers can force the header off or on contextually.

- **Cacheable pages keep the current behavior** — a page with no blocking signal still gets `max-age=300` while its profile is pending.

> [!NOTE]
> Explicit `is_cart()`/`is_checkout()`/`is_account_page()` exclusions are not needed: WooCommerce sets both `DONOTCACHEPAGE` and its no-cache header at `template_redirect`, long before the buffer flush where Optimole runs, so both signals are honored. The same applies to EDD and membership plugins that use `nocache_headers()`.

### Header decision

```mermaid
flowchart LR
    A[Profiling pending<br/>for this page] --> B{New:<br/>DONOTCACHEPAGE<br/>set?}:::added
    B -- Yes --> S[Skip header]
    B -- No --> C{New:<br/>Cache-Control<br/>already set?}:::added
    C -- Yes --> S
    C -- No --> F[New:<br/>optml_send_temporary_cache_header]:::added
    F --> D[Send max-age=300]

    classDef added fill:#1a7f37,color:#fff,stroke:#116329,stroke-width:3px
```

### QA

1. On a connected site with WooCommerce active, clear stored profiles:

   ```bash
   wp transient delete --all
   ```

   Then request the checkout page as a guest:

   ```bash
   curl -sI https://your-site.test/checkout/ | grep -i cache-control
   ```

   **Expect:** `Cache-Control: no-cache, must-revalidate, max-age=0` (WooCommerce's header). Without this fix, the output is `Cache-Control: max-age=300`.

2. Request a plain blog post as a guest directly after clearing transients:

   ```bash
   curl -sI https://your-site.test/hello-world/ | grep -i cache-control
   ```

   **Expect:** `Cache-Control: max-age=300` — the pending-profile behavior on cacheable pages is unchanged.

3. Add `add_filter( 'optml_send_temporary_cache_header', '__return_false' );` to the theme's `functions.php`. Repeat step 2.

   **Expect:** no `Cache-Control: max-age=300` on any page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
