### PR TITLE
Escaped backreferences to prevent XSS

### DIFF
--- a/inc/tag_replacer.php
+++ b/inc/tag_replacer.php
@@ -527,10 +527,12 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 		} else {
 			// Add new srcset attribute
 			$srcset_value = implode( ', ', $new_srcset_entries );
+			// Escape backreference metacharacters so this value can't be expanded by preg_replace() below.
+			$srcset_value = addcslashes( $srcset_value, '\\$' );
 			$srcset_attr = $is_slashed ? 'srcset=\"' . addcslashes( $srcset_value, '"' ) . '\"' : 'srcset="' . $srcset_value . '"';
 
 			// Insert srcset attribute after the src attribute
-			$tag = preg_replace( '/(src=["\'][^"\']*["\'])/i', '$1 ' . addcslashes( $srcset_attr, '\\$' ), $tag );
+			$tag = preg_replace( '/(src=["\'][^"\']*["\'])/i', '$1 ' . $srcset_attr, $tag );
 		}
 
 		// Handle sizes attribute - skip if existing sizes contains calc() or complex formulas
@@ -572,10 +574,12 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 						);
 
 						$sizes_value = implode( ', ', $sizes_entries );
+						// Escape backreference metacharacters before wrapping, see add_missing_srcset_attributes() above.
+						$sizes_value = addcslashes( $sizes_value, '\\$' );
 						$sizes_attr = $is_slashed ? 'sizes=\"' . addcslashes( $sizes_value, '"' ) . '\"' : 'sizes="' . $sizes_value . '"';
 
 						// Insert sizes attribute after srcset
-						$tag = preg_replace( '/(srcset=["\'][^"\']*["\'])/i', '$1 ' . addcslashes( $sizes_attr, '\\$' ), $tag );
+						$tag = preg_replace( '/(srcset=["\'][^"\']*["\'])/i', '$1 ' . $sizes_attr, $tag );
 					}
 				}
 			} else {
@@ -626,10 +630,12 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 			);
 
 			$enhanced_srcset = implode( ', ', $all_entries );
+			// Escape backreference metacharacters so this value can't be expanded by preg_replace() below.
+			$enhanced_srcset = addcslashes( $enhanced_srcset, '\\$' );
 			$srcset_attr = $is_slashed ? 'srcset=\"' . addcslashes( $enhanced_srcset, '"' ) . '\"' : 'srcset="' . $enhanced_srcset . '"';
 
 			// Replace existing srcset
-			$tag = preg_replace( '/srcset=["\'][^"\']*["\']/i', addcslashes( $srcset_attr, '\\$' ), $tag );
+			$tag = preg_replace( '/srcset=["\'][^"\']*["\']/i', $srcset_attr, $tag );
 		}
 
 		return $tag;
@@ -667,10 +673,12 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 			);
 
 			$enhanced_sizes = implode( ', ', $all_entries );
+			// Escape backreference metacharacters before wrapping, see enhance_existing_srcset() above.
+			$enhanced_sizes = addcslashes( $enhanced_sizes, '\\$' );
 			$sizes_attr = $is_slashed ? 'sizes=\"' . addcslashes( $enhanced_sizes, '"' ) . '\"' : 'sizes="' . $enhanced_sizes . '"';
 
 			// Replace existing sizes
-			$tag = preg_replace( '/sizes=["\'][^"\']*["\']/i', addcslashes( $sizes_attr, '\\$' ), $tag );
+			$tag = preg_replace( '/sizes=["\'][^"\']*["\']/i', $sizes_attr, $tag );
 		}
 
 		return $tag;

--- a/inc/tag_replacer.php
+++ b/inc/tag_replacer.php
@@ -530,7 +530,7 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 			$srcset_attr = $is_slashed ? 'srcset=\"' . addcslashes( $srcset_value, '"' ) . '\"' : 'srcset="' . $srcset_value . '"';
 
 			// Insert srcset attribute after the src attribute
-			$tag = preg_replace( '/(src=["\'][^"\']*["\'])/i', '$1 ' . $srcset_attr, $tag );
+			$tag = preg_replace( '/(src=["\'][^"\']*["\'])/i', '$1 ' . addcslashes( $srcset_attr, '\\$' ), $tag );
 		}
 
 		// Handle sizes attribute - skip if existing sizes contains calc() or complex formulas
@@ -575,7 +575,7 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 						$sizes_attr = $is_slashed ? 'sizes=\"' . addcslashes( $sizes_value, '"' ) . '\"' : 'sizes="' . $sizes_value . '"';
 
 						// Insert sizes attribute after srcset
-						$tag = preg_replace( '/(srcset=["\'][^"\']*["\'])/i', '$1 ' . $sizes_attr, $tag );
+						$tag = preg_replace( '/(srcset=["\'][^"\']*["\'])/i', '$1 ' . addcslashes( $sizes_attr, '\\$' ), $tag );
 					}
 				}
 			} else {
@@ -629,7 +629,7 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 			$srcset_attr = $is_slashed ? 'srcset=\"' . addcslashes( $enhanced_srcset, '"' ) . '\"' : 'srcset="' . $enhanced_srcset . '"';
 
 			// Replace existing srcset
-			$tag = preg_replace( '/srcset=["\'][^"\']*["\']/i', $srcset_attr, $tag );
+			$tag = preg_replace( '/srcset=["\'][^"\']*["\']/i', addcslashes( $srcset_attr, '\\$' ), $tag );
 		}
 
 		return $tag;
@@ -670,7 +670,7 @@ final class Optml_Tag_Replacer extends Optml_App_Replacer {
 			$sizes_attr = $is_slashed ? 'sizes=\"' . addcslashes( $enhanced_sizes, '"' ) . '\"' : 'sizes="' . $enhanced_sizes . '"';
 
 			// Replace existing sizes
-			$tag = preg_replace( '/sizes=["\'][^"\']*["\']/i', $sizes_attr, $tag );
+			$tag = preg_replace( '/sizes=["\'][^"\']*["\']/i', addcslashes( $sizes_attr, '\\$' ), $tag );
 		}
 
 		return $tag;

--- a/tests/test-srcset.php
+++ b/tests/test-srcset.php
@@ -534,6 +534,78 @@ class Test_Srcset_Functionality extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a backslash-form "\0" srcset descriptor cannot inject a real onload attribute
+	 */
+	public function test_add_missing_srcset_attributes_prevents_backslash_backreference_injection() {
+		$tag_replacer = new Optml_Tag_Replacer();
+
+		$tag = '<img src="https://example.com/image.jpg" alt="Test" />';
+		$missing_srcsets = [
+			[ 'w' => 800, 'h' => 600, 'd' => 1, 's' => '\0 onload=alert(document.domain) x', 'b' => 0 ],
+		];
+
+		$result = $tag_replacer->add_missing_srcset_attributes( $tag, $missing_srcsets, 'https://example.com/image.jpg', false );
+		$img = $this->get_img_element( $result );
+
+		$this->assertFalse( $img->hasAttribute( 'onload' ) );
+		$this->assertStringContainsString( '\0 onload=alert(document.domain) x', $img->getAttribute( 'srcset' ) );
+	}
+
+	/**
+	 * Test that enhance_existing_srcset does not expand a "\1" entry into a real attribute
+	 */
+	public function test_enhance_existing_srcset_prevents_backslash_backreference_injection() {
+		$tag_replacer = new Optml_Tag_Replacer();
+
+		$tag = '<img src="https://example.com/image.jpg" srcset="existing-300w.jpg 300w" alt="Test" />';
+		$new_entries = [ 'evil.jpg \1 onerror=alert(1) x' ];
+
+		$result = $tag_replacer->enhance_existing_srcset( $tag, $new_entries, false );
+		$img = $this->get_img_element( $result );
+
+		$this->assertFalse( $img->hasAttribute( 'onerror' ) );
+		$this->assertStringContainsString( 'existing-300w.jpg 300w', $img->getAttribute( 'srcset' ) );
+	}
+
+	/**
+	 * Test that the slashed srcset output keeps its required escaping while a "$0" payload stays inert
+	 */
+	public function test_add_missing_srcset_attributes_slashed_prevents_backreference_injection() {
+		$tag_replacer = new Optml_Tag_Replacer();
+
+		$tag = '<img src="https://example.com/image.jpg" alt="Test" />';
+		$missing_srcsets = [
+			[ 'w' => 800, 'h' => 600, 'd' => 1, 's' => '$0 onload=alert(document.domain) x', 'b' => 0 ],
+		];
+
+		$result = $tag_replacer->add_missing_srcset_attributes( $tag, $missing_srcsets, 'https://example.com/image.jpg', true );
+
+		// The required slashed escaping around the srcset value must be preserved as-is (not doubled).
+		$this->assertStringContainsString( 'srcset=\"', $result );
+		$this->assertStringNotContainsString( 'srcset=\\\"', $result );
+		// The payload must stay inert literal text, not become a real attribute breakout.
+		$this->assertStringNotContainsString( '\" onload=', $result );
+		$this->assertStringContainsString( '$0 onload=alert(document.domain) x', $result );
+	}
+
+	/**
+	 * Test that enhance_existing_srcset's slashed output keeps its required escaping while a "\0" payload stays inert
+	 */
+	public function test_enhance_existing_srcset_slashed_prevents_backslash_backreference_injection() {
+		$tag_replacer = new Optml_Tag_Replacer();
+
+		$tag = '<img src="https://example.com/image.jpg" srcset="existing-300w.jpg 300w" alt="Test" />';
+		$new_entries = [ 'evil.jpg \0 onload=alert(document.domain) x' ];
+
+		$result = $tag_replacer->enhance_existing_srcset( $tag, $new_entries, true );
+
+		$this->assertStringContainsString( 'srcset=\"', $result );
+		$this->assertStringNotContainsString( 'srcset=\\\"', $result );
+		$this->assertStringNotContainsString( '\" onload=', $result );
+		$this->assertStringContainsString( 'existing-300w.jpg 300w', $result );
+	}
+
+	/**
 	 * Parse a single img tag string and return its DOM element
 	 */
 	private function get_img_element( $tag_html ) {

--- a/tests/test-srcset.php
+++ b/tests/test-srcset.php
@@ -465,10 +465,91 @@ class Test_Srcset_Functionality extends WP_UnitTestCase {
 
 
 	/**
+	 * Test that a "$0" srcset descriptor cannot inject a real onload attribute
+	 */
+	public function test_add_missing_srcset_attributes_prevents_backreference_injection() {
+		$tag_replacer = new Optml_Tag_Replacer();
+
+		$tag = '<img src="https://example.com/image.jpg" alt="Test" />';
+		$missing_srcsets = [
+			[ 'w' => 800, 'h' => 600, 'd' => 1, 's' => '$0 onload=alert(document.domain) x', 'b' => 0 ],
+		];
+
+		$result = $tag_replacer->add_missing_srcset_attributes( $tag, $missing_srcsets, 'https://example.com/image.jpg', false );
+		$img = $this->get_img_element( $result );
+
+		// The payload must stay inert literal text inside the srcset value, not become a real attribute
+		$this->assertFalse( $img->hasAttribute( 'onload' ) );
+		$this->assertStringContainsString( '$0 onload=alert(document.domain) x', $img->getAttribute( 'srcset' ) );
+	}
+
+	/**
+	 * Test that a "$1" srcset descriptor cannot inject a real onerror attribute
+	 */
+	public function test_add_missing_srcset_attributes_prevents_dollar_one_injection() {
+		$tag_replacer = new Optml_Tag_Replacer();
+
+		$tag = '<img src="https://example.com/image.jpg" alt="Test" />';
+		$missing_srcsets = [
+			[ 'w' => 800, 'h' => 600, 'd' => 1, 's' => '$1 onerror=alert(1) x', 'b' => 0 ],
+		];
+
+		$result = $tag_replacer->add_missing_srcset_attributes( $tag, $missing_srcsets, 'https://example.com/image.jpg', false );
+		$img = $this->get_img_element( $result );
+
+		$this->assertFalse( $img->hasAttribute( 'onerror' ) );
+		$this->assertSame( 'https://example.com/image.jpg', $img->getAttribute( 'src' ) );
+	}
+
+	/**
+	 * Test that enhance_existing_srcset does not expand a "$0" entry into a real attribute
+	 */
+	public function test_enhance_existing_srcset_prevents_backreference_injection() {
+		$tag_replacer = new Optml_Tag_Replacer();
+
+		$tag = '<img src="https://example.com/image.jpg" srcset="existing-300w.jpg 300w" alt="Test" />';
+		$new_entries = [ 'evil.jpg $0 onload=alert(document.domain) x' ];
+
+		$result = $tag_replacer->enhance_existing_srcset( $tag, $new_entries, false );
+		$img = $this->get_img_element( $result );
+
+		$this->assertFalse( $img->hasAttribute( 'onload' ) );
+		$this->assertStringContainsString( 'existing-300w.jpg 300w', $img->getAttribute( 'srcset' ) );
+	}
+
+	/**
+	 * Test that enhance_existing_sizes does not expand a "$0" entry into a real attribute
+	 */
+	public function test_enhance_existing_sizes_prevents_backreference_injection() {
+		$tag_replacer = new Optml_Tag_Replacer();
+
+		$tag = '<img src="https://example.com/image.jpg" sizes="(max-width: 480px) 300px" alt="Test" />';
+		$new_entries = [ '$0 onload=alert(document.domain) x' ];
+
+		$result = $tag_replacer->enhance_existing_sizes( $tag, $new_entries, false );
+		$img = $this->get_img_element( $result );
+
+		$this->assertFalse( $img->hasAttribute( 'onload' ) );
+		$this->assertStringContainsString( '(max-width: 480px) 300px', $img->getAttribute( 'sizes' ) );
+	}
+
+	/**
+	 * Parse a single img tag string and return its DOM element
+	 */
+	private function get_img_element( $tag_html ) {
+		$dom = new DOMDocument();
+		$previous_setting = libxml_use_internal_errors( true );
+		$dom->loadHTML( $tag_html );
+		libxml_use_internal_errors( $previous_setting );
+
+		return $dom->getElementsByTagName( 'img' )->item( 0 );
+	}
+
+	/**
 	 * Set up test environment
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		
+
 	}
 }


### PR DESCRIPTION
### Summary:
The 4.2.3 fix for `CVE-2026-5217` escaped the srcset descriptor with `esc_attr()`, but the escaped value is then passed as the replacement argument of `preg_replace()`, which still expands `$0/$1` backreferences and can reinsert a raw double quote to break out of the attribute. Escape $ and \ with `addcslashes()` right before each `preg_replace()` call in `add_missing_srcset_attributes()`, `enhance_existing_srcset()`, and `enhance_existing_sizes()`.

### All Submissions:

* [x] Have you followed the [Optimole Contributing guideline](https://github.com/Codeinwp/optimole-wp/blob/master/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 
 

Closes https://github.com/Codeinwp/optimole-service/issues/1780

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
 
