### PR TITLE
feat: use the modern dashboard API for connect, cache tokens, extra visits and metadata sync

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -1143,7 +1143,7 @@ class Optml_Admin {
 
 		$request = new Optml_Api();
 		$data    = $request->get_user_data( $api_key, $application );
-		if ( $data === false || is_wp_error( $data ) ) {
+		if ( is_wp_error( $data ) ) {
 			return;
 		}
 		if ( $data === 'disconnect' ) {

--- a/inc/api.php
+++ b/inc/api.php
@@ -166,16 +166,33 @@ final class Optml_Api {
 		return $original_image_url;
 	}
 	/**
-	 * Get user data from service.
+	 * Get the account context from the service.
 	 *
-	 * @return array|string|bool|WP_Error User data.
+	 * Returns the string "disconnect" when the service refuses the key or the site can no
+	 * longer be whitelisted, so callers drop the stored connection.
+	 *
+	 * @param string $api_key Api key.
+	 * @param string $application Unused, kept for callers passing the application key.
+	 *
+	 * @return array<string, mixed>|string|WP_Error User data, "disconnect", or an API error.
 	 */
 	public function get_user_data( $api_key = '', $application = '' ) {
 		if ( ! empty( $api_key ) ) {
 			$this->api_key = $api_key;
 		}
 
-		return $this->request( '/optml/v2/account/details', 'POST', [ 'application' => $application ] );
+		$response = $this->modern_request( 'integrations/wordpress/context', 'POST', [ 'site' => get_home_url() ] );
+
+		if ( is_wp_error( $response ) ) {
+			$status = $response->get_error_data();
+			$status = is_array( $status ) && isset( $status['status'] ) ? (int) $status['status'] : 0;
+
+			if ( 'whitelist_limit_reached' === $response->get_error_code() || in_array( $status, [ 401, 403 ], true ) ) {
+				return 'disconnect';
+			}
+		}
+
+		return $response;
 	}
 
 	/**
@@ -281,16 +298,6 @@ final class Optml_Api {
 				}
 			}
 
-			if ( $path === '/optml/v2/account/details'
-				&& isset( $response['code'] ) && $response['code'] === 'not_allowed' ) {
-				return 'disconnect';
-			}
-
-			if ( $path === '/optml/v2/account/details'
-				&& isset( $response['error'] ) && $response['error'] === 'whitelist_limit_reached' ) {
-				return 'disconnect';
-			}
-
 			return isset( $response['error'] ) ? new WP_Error(
 				'api_error',
 				wp_kses(
@@ -328,7 +335,7 @@ final class Optml_Api {
 	 * @param string               $method HTTP method.
 	 * @param array<string, mixed> $params JSON body for writes, query string for GET.
 	 *
-	 * @return array<string, mixed>|WP_Error The decoded body (empty for 204), or an error carrying the API error code.
+	 * @return array<string, mixed>|WP_Error The decoded body (empty for 204), or an error carrying the API error code and the HTTP status in its data.
 	 */
 	private function modern_request( $path, $method = 'GET', $params = [] ) {
 		$url = trailingslashit( $this->api_root ) . ltrim( $path, '/' );
@@ -391,7 +398,8 @@ final class Optml_Api {
 						'target' => [],
 					],
 				]
-			)
+			),
+			[ 'status' => $status ]
 		);
 	}
 

--- a/inc/api.php
+++ b/inc/api.php
@@ -51,18 +51,94 @@ final class Optml_Api {
 	}
 
 	/**
-	 * Connect to the service.
+	 * Connect the current site to the account behind the API key.
+	 *
+	 * Talks to the modern connection endpoint and shapes its answer like the legacy
+	 * connect payload (app_count, extra_visits, available_apps) the plugin UI consumes.
 	 *
 	 * @param string $api_key Api key.
 	 *
-	 * @return array|bool|WP_Error
+	 * @return array<string, mixed>|false|WP_Error
 	 */
 	public function connect( $api_key = '' ) {
 		if ( ! empty( $api_key ) ) {
 			$this->api_key = $api_key;
 		}
 
-		return $this->request( '/optml/v2/account/connect', 'POST', [ 'sample_image' => $this->get_sample_image() ] );
+		$response = $this->modern_request(
+			'integrations/wordpress/connections',
+			'POST',
+			[
+				'domain'       => get_home_url(),
+				'sample_image' => $this->get_sample_image(),
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			if ( $response->get_error_code() === 'domain_not_accessible' ) {
+				return $this->domain_not_accessible_error();
+			}
+
+			return $response;
+		}
+
+		if ( ! isset( $response['application'] ) || ! is_array( $response['application'] ) ) {
+			return false;
+		}
+
+		$application    = $response['application'];
+		$custom_domains = isset( $response['custom_domains'] ) && is_array( $response['custom_domains'] ) ? $response['custom_domains'] : [];
+		$domains_limit  = isset( $application['limits']['custom_domains'] ) ? (int) $application['limits']['custom_domains'] : 0;
+
+		return [
+			'app_count'      => $domains_limit > 0 ? $domains_limit : 1,
+			'extra_visits'   => ! empty( $response['extra_visits'] ),
+			'available_apps' => $this->build_available_apps( $application, $custom_domains ),
+		];
+	}
+
+	/**
+	 * Shape the modern connection response into the application list the dashboard UI expects.
+	 *
+	 * Mirrors the legacy "available_apps" payload: one entry per active custom domain, or the
+	 * default Optimole domain when the plan has none.
+	 *
+	 * @param array<string, mixed>             $application    The application resource.
+	 * @param array<int, array<string, mixed>> $custom_domains The active custom domains.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function build_available_apps( array $application, array $custom_domains ) {
+		$default_app = [
+			'key'               => isset( $application['key'] ) ? (string) $application['key'] : '',
+			'status'            => ( $application['status'] ?? '' ) === 'active' ? 'active' : 'inactive',
+			'domain'            => (string) ( $application['default_domain'] ?? ( $application['domain'] ?? '' ) ),
+			'is_cname_assigned' => 'no',
+			'cf_ssl_registered' => 'no',
+			'certificate_arn'   => '',
+			'limit_wl_sites'    => isset( $application['limits']['sites'] ) ? (int) $application['limits']['sites'] : 0,
+		];
+
+		if ( empty( $application['capabilities']['custom_domains'] ) ) {
+			return [ $default_app ];
+		}
+
+		$apps = [];
+		foreach ( $custom_domains as $custom_domain ) {
+			if ( ! is_array( $custom_domain ) || empty( $custom_domain['domain'] ) ) {
+				continue;
+			}
+			$apps[] = array_merge(
+				$default_app,
+				[
+					'domain'            => (string) $custom_domain['domain'],
+					'is_cname_assigned' => 'yes',
+					'cf_ssl_registered' => 'yes',
+				]
+			);
+		}
+
+		return empty( $apps ) ? [ $default_app ] : $apps;
 	}
 
 	/**
@@ -107,21 +183,22 @@ final class Optml_Api {
 	 *
 	 * @param string $api_key Api key.
 	 * @param string $status Status of the visits toggle.
+	 * @param string $application Unused, kept for callers passing the application key.
 	 *
-	 * @return array|bool|string
+	 * @return array<string, mixed>|WP_Error
 	 */
 	public function update_extra_visits( $api_key = '', $status = 'enabled', $application = '' ) {
 		if ( ! empty( $api_key ) ) {
 			$this->api_key = $api_key;
 		}
 
-		return $this->request( '/optml/v2/account/extra_visits', 'POST', [ 'extra_visits' => $status, 'application' => $application ] );
+		return $this->modern_request( 'application/extra-visits', 'PUT', [ 'enabled' => 'enabled' === $status ] );
 	}
 
 	/**
-	 * Get cache token from service.
+	 * Get a new cache-busting token from the service.
 	 *
-	 * @return array|bool|WP_Error User data.
+	 * @return array<string, mixed>|WP_Error The token payload, or a throttle/API error.
 	 */
 	public function get_cache_token( $token = '', $type = '', $api_key = '' ) {
 		if ( ! empty( $api_key ) ) {
@@ -139,7 +216,7 @@ final class Optml_Api {
 		if ( $lock === 'yes' ) {
 			return new WP_Error( 'cache_throttle', __( 'You can clear cache only once per 5 minutes.', 'optimole-wp' ) );
 		}
-		return $this->request( '/optml/v1/cache/tokens', 'POST', [ 'token' => $token, 'type' => $type ] );
+		return $this->modern_request( 'cache-tokens', 'POST' );
 	}
 
 	/**
@@ -192,7 +269,7 @@ final class Optml_Api {
 
 		if ( intval( $response['code'] ) !== 200 ) {
 			if ( isset( $response['error'] ) && $response['error'] === 'domain_not_accessible' ) {
-				return new WP_Error( 'domain_not_accessible', sprintf( /* translators: 1 start of the italic tag, 2 is the end of italic tag,  3 is starting anchor tag, 4 is the ending anchor tag. */ __( 'It seems Optimole is having trouble reaching your website. This issue often occurs if your website is private, local, or protected by a firewall. But don\'t stress – it\'s an easy fix! Ensure your website is live and accessible to the public. If a firewall is in place, just tweak the settings to allow the %1$sOptimole(1.0)%2$s user agent access to your website. %3$sLearn More%4$s', 'optimole-wp' ), '<i>', '</i>', '<a href="https://docs.optimole.com/article/1976-resolving-optimole-access-to-your-website" target="_blank">', '</a>' ) );
+				return $this->domain_not_accessible_error();
 			}
 			if ( $path === 'optml/v2/account/complete_register_remote' && isset( $response['error'] ) ) {
 				if ( strpos( $response['error'], 'This email address is already registered.' ) !== false ) {
@@ -229,6 +306,93 @@ final class Optml_Api {
 		}
 
 		return $response['data'];
+	}
+
+	/**
+	 * The error the connect flow returns when Optimole cannot reach the site.
+	 *
+	 * @return WP_Error
+	 */
+	private function domain_not_accessible_error() {
+		return new WP_Error( 'domain_not_accessible', sprintf( /* translators: 1 start of the italic tag, 2 is the end of italic tag,  3 is starting anchor tag, 4 is the ending anchor tag. */ __( 'It seems Optimole is having trouble reaching your website. This issue often occurs if your website is private, local, or protected by a firewall. But don\'t stress – it\'s an easy fix! Ensure your website is live and accessible to the public. If a firewall is in place, just tweak the settings to allow the %1$sOptimole(1.0)%2$s user agent access to your website. %3$sLearn More%4$s', 'optimole-wp' ), '<i>', '</i>', '<a href="https://docs.optimole.com/article/1976-resolving-optimole-access-to-your-website" target="_blank">', '</a>' ) );
+	}
+
+	/**
+	 * Call the current dashboard API (the /api/* routes).
+	 *
+	 * Unlike the legacy optml/v2 routes, these return the resource directly and report
+	 * failures through the HTTP status, with a JSON body carrying "message" and, for
+	 * known failures, a "code" the caller can branch on.
+	 *
+	 * @param string               $path   Route path, relative to the API root.
+	 * @param string               $method HTTP method.
+	 * @param array<string, mixed> $params JSON body for writes, query string for GET.
+	 *
+	 * @return array<string, mixed>|WP_Error The decoded body (empty for 204), or an error carrying the API error code.
+	 */
+	private function modern_request( $path, $method = 'GET', $params = [] ) {
+		$url = trailingslashit( $this->api_root ) . ltrim( $path, '/' );
+		if ( 'GET' === $method && ! empty( $params ) ) {
+			$url = add_query_arg( $params, $url );
+		}
+		$url = tsdk_translate_link( $url, 'query' );
+
+		$headers = [
+			'Optml-Site' => get_home_url(),
+			'Accept'     => 'application/json',
+		];
+		if ( ! empty( $this->api_key ) ) {
+			$headers['Authorization'] = 'Bearer ' . $this->api_key;
+		}
+
+		$args = [
+			'method'     => $method,
+			'timeout'    => 45,
+			'user-agent' => 'Optimle WP (v' . OPTML_VERSION . ') ',
+			'sslverify'  => false,
+			'headers'    => $headers,
+		];
+		if ( 'GET' !== $method ) {
+			$args['headers']['Content-Type'] = 'application/json';
+			$args['body']                    = wp_json_encode( $params );
+		}
+
+		$response = wp_remote_request( $url, $args );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
+		$body   = is_array( $body ) ? $body : [];
+
+		if ( $status >= 200 && $status < 300 ) {
+			return $body;
+		}
+
+		$message = isset( $body['message'] ) && is_string( $body['message'] ) ? $body['message'] : '';
+		if ( '' === $message && ! empty( $body['errors'] ) && is_array( $body['errors'] ) ) {
+			$first_error = reset( $body['errors'] );
+			$first_error = is_array( $first_error ) ? reset( $first_error ) : $first_error;
+			$message     = is_scalar( $first_error ) ? (string) $first_error : '';
+		}
+		if ( '' === $message ) {
+			$message = sprintf( /* translators: %d is the HTTP status code. */ __( 'Unexpected response from the Optimole service (HTTP %d).', 'optimole-wp' ), $status );
+		}
+		$code = isset( $body['code'] ) && is_string( $body['code'] ) && '' !== $body['code'] ? $body['code'] : 'api_error';
+
+		return new WP_Error(
+			$code,
+			wp_kses(
+				$message,
+				[
+					'a' => [
+						'href'   => [],
+						'target' => [],
+					],
+				]
+			)
+		);
 	}
 
 	/**
@@ -307,11 +471,40 @@ final class Optml_Api {
 	/**
 	 * Send a list of images with alt/title values to update.
 	 *
-	 * @param array $images List of images.
-	 * @return array
+	 * @param array<string, array<string, mixed>> $images Alt/title data keyed by image URL.
+	 * @return true|WP_Error
 	 */
 	public function call_data_enrich_api( $images = [] ) {
-		return $this->request( 'optml/v2/media/add_data', 'POST', [ 'images' => $images, 'key' => Optml_Config::$key ] );
+		$assets = [];
+		foreach ( $images as $url => $data ) {
+			if ( ! is_string( $url ) || '' === $url || ! is_array( $data ) ) {
+				continue;
+			}
+			$asset = [ 'url' => $url ];
+			foreach ( [ 'title', 'alt' ] as $attribute ) {
+				if ( ! empty( $data[ $attribute ] ) && is_scalar( $data[ $attribute ] ) ) {
+					$asset[ $attribute ] = mb_substr( (string) $data[ $attribute ], 0, 255 );
+				}
+			}
+			if ( count( $asset ) === 1 ) {
+				continue;
+			}
+			$assets[] = $asset;
+		}
+
+		if ( empty( $assets ) ) {
+			return true;
+		}
+
+		// The dashboard accepts at most 100 assets per call.
+		foreach ( array_chunk( $assets, 100 ) as $chunk ) {
+			$response = $this->modern_request( 'assets', 'PATCH', [ 'assets' => $chunk ] );
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
+		}
+
+		return true;
 	}
 	/**
 	 * Register user remotely on optimole.com.
@@ -354,28 +547,6 @@ final class Optml_Api {
 		return $this->request( '/optml/v1/stats/images', 'GET', [], [ 'application' => $app_key ] );
 	}
 
-	/**
-	 * Call the images endpoint.
-	 *
-	 * @param integer $page Page used to advance the search.
-	 * @param array   $domains Domains to filter by.
-	 * @param string  $search The string to search inside the originURL.
-	 * @return mixed The decoded json response from the api.
-	 */
-	public function get_cloud_images( $page = 0, $domains = [], $search = '' ) {
-
-		$params = [ 'key' => Optml_Config::$key ];
-		$params['page'] = $page;
-		$params['size'] = 40;
-		if ( $search !== '' ) {
-			$params['search'] = $search;
-		}
-
-		if ( ! empty( $domains ) ) {
-			$params['domains'] = implode( ',', $domains );
-		}
-		return $this->request( 'optml/v2/media/browser', 'GET', $params );
-	}
 	/**
 	 * Get offload conflicts.
 	 *

--- a/inc/cli/cli_setting.php
+++ b/inc/cli/cli_setting.php
@@ -29,7 +29,7 @@ class Optml_Cli_Setting extends WP_CLI_Command {
 
 		$request = new Optml_Api();
 		$data    = $request->get_user_data( $api_key );
-		if ( $data === false || is_wp_error( $data ) ) {
+		if ( ! is_array( $data ) ) {
 			$extra = '';
 			if ( is_wp_error( $data ) ) {
 				$extra = sprintf(

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -416,14 +416,9 @@ class Optml_Rest {
 		$application = $request->get_param( 'application' );
 		$request = new Optml_Api();
 		$data    = $request->get_user_data( $api_key, $application );
-		if ( $data === false || is_wp_error( $data ) ) {
+		if ( ! is_array( $data ) ) {
 			$extra = '';
 			if ( is_wp_error( $data ) ) {
-				/**
-				 * Error from api.
-				 *
-				 * @var WP_Error $data Error object.
-				 */
 				$extra = sprintf( /* translators: Error details */ __( '. ERROR details: %s', 'optimole-wp' ), $data->get_error_message() );
 			}
 			wp_send_json_error( __( 'Can not connect to Optimole service', 'optimole-wp' ) . $extra );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -349,18 +349,6 @@ parameters:
 			path: inc/api.php
 
 		-
-			message: '#^Method Optml_Api\:\:call_data_enrich_api\(\) has parameter \$images with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: inc/api.php
-
-		-
-			message: '#^Method Optml_Api\:\:call_data_enrich_api\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: inc/api.php
-
-		-
 			message: '#^Method Optml_Api\:\:call_onboard_api\(\) has parameter \$images with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -368,12 +356,6 @@ parameters:
 
 		-
 			message: '#^Method Optml_Api\:\:call_onboard_api\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: inc/api.php
-
-		-
-			message: '#^Method Optml_Api\:\:connect\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: inc/api.php
@@ -399,18 +381,6 @@ parameters:
 		-
 			message: '#^Method Optml_Api\:\:get_cache_token\(\) has parameter \$type with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: inc/api.php
-
-		-
-			message: '#^Method Optml_Api\:\:get_cache_token\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: inc/api.php
-
-		-
-			message: '#^Method Optml_Api\:\:get_cloud_images\(\) has parameter \$domains with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: inc/api.php
 
@@ -470,18 +440,6 @@ parameters:
 
 		-
 			message: '#^Method Optml_Api\:\:request\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: inc/api.php
-
-		-
-			message: '#^Method Optml_Api\:\:update_extra_visits\(\) has parameter \$application with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: inc/api.php
-
-		-
-			message: '#^Method Optml_Api\:\:update_extra_visits\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: inc/api.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -397,24 +397,6 @@ parameters:
 			path: inc/api.php
 
 		-
-			message: '#^Method Optml_Api\:\:get_user_data\(\) has parameter \$api_key with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: inc/api.php
-
-		-
-			message: '#^Method Optml_Api\:\:get_user_data\(\) has parameter \$application with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: inc/api.php
-
-		-
-			message: '#^Method Optml_Api\:\:get_user_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: inc/api.php
-
-		-
 			message: '#^Method Optml_Api\:\:log_offload_error\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1


### PR DESCRIPTION
The plugin talks to the dashboard through legacy `optml/v2` and `optml/v1` routes that Optimole is retiring. This PR moves five of its calls to the modern `/api/*` endpoints added in [optimole-service #1789](https://github.com/Codeinwp/optimole-service/pull/1789) and removes a dead client method.

> [!NOTE]
> Depends on optimole-service #1789 being deployed to production first. Until then the five modern calls below return 404 against production, so this PR stays a draft. Set `OPTIML_API_ROOT` to the staging dashboard to test it before that deploy. Installed plugin versions are not affected either way: #1789 also serves the legacy paths from the same actions, so the switch here is about calling the modern contract directly, not about keeping old installs working.

## What changed

- **Connect** — `Optml_Api::connect()` posts to `POST /api/integrations/wordpress/connections` with the site URL and the sample image, then shapes the answer into the `app_count`, `extra_visits` and `available_apps` payload the connect screen already consumes. The `domain_not_accessible` error keeps the plugin's own translated message with the docs link.

- **Clear cache** — `get_cache_token()` posts to `POST /api/cache-tokens`. The 5-minute local throttle is unchanged; the legacy route ignored the token and type parameters the plugin sent, so nothing is lost by dropping them.

- **Banner extra visits** — `update_extra_visits()` sends `PUT /api/application/extra-visits` with `{"enabled": bool}`.

- **Alt and title sync** — `call_data_enrich_api()` sends `PATCH /api/assets` with one entry per image URL, in chunks of 100, and trims values to the 255 characters the endpoint accepts. Images that were never offloaded are ignored by the dashboard, so a full media library sync no longer needs the server-side URL lookup the legacy route did.

- **Account context** — `get_user_data()` posts to `POST /api/integrations/wordpress/context` with the site URL and receives the same flat payload the plugin already stores as `service_data`. A refused key (401/403) or a `whitelist_limit_reached` error still yields the `disconnect` signal the admin screen acts on.

- **API client** — new private `modern_request()` handles the modern envelope: the resource comes back directly, failures arrive as HTTP errors with a `message` and an optional `code`, which becomes the `WP_Error` code. The legacy `request()` stays for `complete_register_remote`, `v1/stats/images` and `logs`.

- **Removed** — `get_cloud_images()` had no caller since the DAM replaced the cloud images modal. Its PHPStan baseline entries go with it.

## Calls after this PR

| Plugin method | Endpoint | Layer |
|---|---|---|
| `connect()` | `POST /api/integrations/wordpress/connections` | modern |
| `get_cache_token()` | `POST /api/cache-tokens` | modern |
| `update_extra_visits()` | `PUT /api/application/extra-visits` | modern |
| `call_data_enrich_api()` | `PATCH /api/assets` | modern |
| `get_user_data()` | `POST /api/integrations/wordpress/context` | modern |
| `create_account()` | `POST /api/optml/v2/account/complete_register_remote` | legacy |
| `get_optimized_images()` | `GET /api/optml/v1/stats/images` | legacy |
| `send_log()` | `POST /api/optml/v2/logs` | legacy |

## QA

Run these on a site whose `wp-config.php` defines `OPTIML_API_ROOT` as `https://staging-dashboard.optimole.com/api/`, with an API key from a staging account.

1. Go to `WP Admin → Media → Optimole`, paste the API key and click **Connect to Optimole**.

   **Expect:** the dashboard widget loads with plan and quota, and the site appears under `Whitelist` in the staging dashboard. On an account with two active custom domains, the domain picker appears first.

2. Connect with a key from a free staging account for a domain that sits on a trashed application of another free account.

   **Expect:** the connect screen shows the "previously connected to an Optimole account that is now disabled" message and no key is stored.

3. Go to `WP Admin → Media → Optimole → Settings → General` and click **Clear cached images**.

   **Expect:** a success notice, and a second click within five minutes shows the "once per 5 minutes" throttle message.

4. Go to `WP Admin → Media → Optimole → Settings → General`, turn on the **Badge settings** toggle (the Optimole badge that grants extra visits), save, then reload the settings page.

   **Expect:** the toggle stays on, and `POST /api/optml/v2/account/details` for that key returns `"extra_visits":true` right away.

5. Offload one image, set its alt text in `Media → Library`, and wait for the next metadata sync cron run (or trigger `wp cron event run optml_pull_image_data`).

   **Expect:** the image in the staging dashboard library shows the new alt text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
